### PR TITLE
feat(binding): trigger+binding integration tests and example (Phase 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,53 @@ with DbWriter(url="%DB_URL%", table="orders") as writer:
 
 Supported upsert dialects: PostgreSQL, SQLite, MySQL.
 
+### Combined: Trigger + Binding
+
+Process database changes and write results to another table. Uses `EngineProvider` for shared connection pooling.
+
+```python
+from azure_functions_db import (
+    DbWriter, EngineProvider, PollTrigger, SqlAlchemySource, BlobCheckpointStore,
+)
+
+engine_provider = EngineProvider()
+
+trigger = PollTrigger(
+    name="orders",
+    source=SqlAlchemySource(
+        url="%SOURCE_DB_URL%",
+        table="orders",
+        cursor_column="updated_at",
+        pk_columns=["id"],
+        engine_provider=engine_provider,
+    ),
+    checkpoint_store=BlobCheckpointStore(
+        connection="AzureWebJobsStorage",
+        container="db-state",
+    ),
+)
+
+def process_orders(events):
+    with DbWriter(
+        url="%DEST_DB_URL%", table="processed_orders",
+        engine_provider=engine_provider,
+    ) as writer:
+        for event in events:
+            writer.upsert(
+                data={
+                    "order_id": event.pk["id"],
+                    "customer": event.after["name"],
+                    "processed_at": event.cursor,
+                },
+                conflict_columns=["order_id"],
+            )
+
+# In your Azure Function:
+# trigger.run(timer=timer, handler=process_orders)
+```
+
+See [`examples/trigger_with_binding/`](examples/trigger_with_binding/) for a complete runnable sample.
+
 ## Supported Databases
 
 | Database | Extra | Driver |

--- a/README.md
+++ b/README.md
@@ -160,24 +160,31 @@ Supported upsert dialects: PostgreSQL, SQLite, MySQL.
 Process database changes and write results to another table. Uses `EngineProvider` for shared connection pooling.
 
 ```python
+from azure.storage.blob import ContainerClient
+
 from azure_functions_db import (
-    DbWriter, EngineProvider, PollTrigger, SqlAlchemySource, BlobCheckpointStore,
+    BlobCheckpointStore, DbWriter, EngineProvider, PollTrigger, SqlAlchemySource,
 )
 
 engine_provider = EngineProvider()
 
+source = SqlAlchemySource(
+    url="%SOURCE_DB_URL%",
+    table="orders",
+    cursor_column="updated_at",
+    pk_columns=["id"],
+    engine_provider=engine_provider,
+)
+
 trigger = PollTrigger(
     name="orders",
-    source=SqlAlchemySource(
-        url="%SOURCE_DB_URL%",
-        table="orders",
-        cursor_column="updated_at",
-        pk_columns=["id"],
-        engine_provider=engine_provider,
-    ),
+    source=source,
     checkpoint_store=BlobCheckpointStore(
-        connection="AzureWebJobsStorage",
-        container="db-state",
+        container_client=ContainerClient.from_connection_string(
+            conn_str="%AzureWebJobsStorage%",
+            container_name="db-state",
+        ),
+        source_fingerprint=source.source_descriptor.fingerprint,
     ),
 )
 
@@ -187,14 +194,15 @@ def process_orders(events):
         engine_provider=engine_provider,
     ) as writer:
         for event in events:
-            writer.upsert(
-                data={
-                    "order_id": event.pk["id"],
-                    "customer": event.after["name"],
-                    "processed_at": event.cursor,
-                },
-                conflict_columns=["order_id"],
-            )
+            if event.after is not None:
+                writer.upsert(
+                    data={
+                        "order_id": event.pk["id"],
+                        "customer": event.after["name"],
+                        "processed_at": str(event.cursor),
+                    },
+                    conflict_columns=["order_id"],
+                )
 
 # In your Azure Function:
 # trigger.run(timer=timer, handler=process_orders)

--- a/docs/21-dev-checklist.md
+++ b/docs/21-dev-checklist.md
@@ -75,7 +75,7 @@
 - [x] Integration tests (SQLite)
 
 ## Phase 11: Binding Integration
-- [ ] Trigger + output binding combined example
-- [ ] Binding decorator sugar (optional)
-- [ ] Docs update
-- [ ] Sample function_app.py with binding
+- [x] Trigger + output binding combined example
+- [x] Binding decorator sugar (optional)
+- [x] Docs update
+- [x] Sample function_app.py with binding

--- a/docs/21-dev-checklist.md
+++ b/docs/21-dev-checklist.md
@@ -76,6 +76,6 @@
 
 ## Phase 11: Binding Integration
 - [x] Trigger + output binding combined example
-- [x] Binding decorator sugar (optional)
+- [ ] Binding decorator sugar (future: API redesign)
 - [x] Docs update
 - [x] Sample function_app.py with binding

--- a/examples/trigger_with_binding/function_app.py
+++ b/examples/trigger_with_binding/function_app.py
@@ -1,0 +1,76 @@
+"""Trigger + Binding integration example.
+
+Demonstrates using PollTrigger to detect DB changes and DbWriter to write
+processed results to a destination table.  Uses EngineProvider for shared
+connection pooling across trigger and bindings.
+
+Requirements:
+    pip install azure-functions-db[postgres]
+    # or: pip install azure-functions-db[all]
+
+Environment variables:
+    SOURCE_DB_URL: Source database connection URL
+    DEST_DB_URL: Destination database connection URL
+    AzureWebJobsStorage: Azure Storage connection string (for checkpoint)
+"""
+
+from __future__ import annotations
+
+import azure.functions as func
+
+from azure_functions_db import (
+    BlobCheckpointStore,
+    DbReader,
+    DbWriter,
+    EngineProvider,
+    PollTrigger,
+    SqlAlchemySource,
+)
+from azure_functions_db.trigger.events import RowChange
+
+app = func.FunctionApp()
+
+engine_provider = EngineProvider()
+
+orders_trigger = PollTrigger(
+    name="orders",
+    source=SqlAlchemySource(
+        url="%SOURCE_DB_URL%",
+        table="orders",
+        schema="public",
+        cursor_column="updated_at",
+        pk_columns=["id"],
+        engine_provider=engine_provider,
+    ),
+    checkpoint_store=BlobCheckpointStore(
+        connection="AzureWebJobsStorage",
+        container="db-state",
+    ),
+    batch_size=100,
+    max_batches_per_tick=1,
+)
+
+
+def process_orders(events: list[RowChange]) -> None:
+    with DbWriter(
+        url="%DEST_DB_URL%",
+        table="processed_orders",
+        engine_provider=engine_provider,
+    ) as writer:
+        for event in events:
+            row = event.after
+            writer.upsert(
+                data={
+                    "order_id": event.pk["id"],
+                    "customer_name": row["name"],
+                    "amount": row["amount"],
+                    "processed_at": event.cursor,
+                },
+                conflict_columns=["order_id"],
+            )
+
+
+@app.function_name(name="orders_poll")
+@app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
+def orders_poll(timer: func.TimerRequest) -> None:
+    orders_trigger.run(timer=timer, handler=process_orders)

--- a/examples/trigger_with_binding/function_app.py
+++ b/examples/trigger_with_binding/function_app.py
@@ -17,10 +17,10 @@ Environment variables:
 from __future__ import annotations
 
 import azure.functions as func
+from azure.storage.blob import ContainerClient
 
 from azure_functions_db import (
     BlobCheckpointStore,
-    DbReader,
     DbWriter,
     EngineProvider,
     PollTrigger,
@@ -32,19 +32,24 @@ app = func.FunctionApp()
 
 engine_provider = EngineProvider()
 
+source = SqlAlchemySource(
+    url="%SOURCE_DB_URL%",
+    table="orders",
+    schema="public",
+    cursor_column="updated_at",
+    pk_columns=["id"],
+    engine_provider=engine_provider,
+)
+
 orders_trigger = PollTrigger(
     name="orders",
-    source=SqlAlchemySource(
-        url="%SOURCE_DB_URL%",
-        table="orders",
-        schema="public",
-        cursor_column="updated_at",
-        pk_columns=["id"],
-        engine_provider=engine_provider,
-    ),
+    source=source,
     checkpoint_store=BlobCheckpointStore(
-        connection="AzureWebJobsStorage",
-        container="db-state",
+        container_client=ContainerClient.from_connection_string(
+            conn_str="%AzureWebJobsStorage%",
+            container_name="db-state",
+        ),
+        source_fingerprint=source.source_descriptor.fingerprint,
     ),
     batch_size=100,
     max_batches_per_tick=1,
@@ -58,16 +63,16 @@ def process_orders(events: list[RowChange]) -> None:
         engine_provider=engine_provider,
     ) as writer:
         for event in events:
-            row = event.after
-            writer.upsert(
-                data={
-                    "order_id": event.pk["id"],
-                    "customer_name": row["name"],
-                    "amount": row["amount"],
-                    "processed_at": event.cursor,
-                },
-                conflict_columns=["order_id"],
-            )
+            if event.after is not None:
+                writer.upsert(
+                    data={
+                        "order_id": event.pk["id"],
+                        "customer_name": event.after["name"],
+                        "amount": event.after["amount"],
+                        "processed_at": str(event.cursor),
+                    },
+                    conflict_columns=["order_id"],
+                )
 
 
 @app.function_name(name="orders_poll")

--- a/tests/test_binding_integration.py
+++ b/tests/test_binding_integration.py
@@ -130,6 +130,7 @@ class TestTriggerWithWriter:
         def handler(events: list[RowChange]) -> None:
             with DbWriter(url=dest_url, table="processed") as writer:
                 for event in events:
+                    assert event.after is not None  # noqa: S101  # nosec B101
                     writer.insert(
                         data={
                             "id": event.pk["id"],
@@ -168,6 +169,7 @@ class TestTriggerWithWriter:
         def handler(events: list[RowChange]) -> None:
             with DbWriter(url=dest_url, table="processed") as writer:
                 for event in events:
+                    assert event.after is not None  # noqa: S101  # nosec B101
                     writer.upsert(
                         data={
                             "id": event.pk["id"],
@@ -228,7 +230,7 @@ class TestTriggerWithReaderAndWriter:
         assert count == 3
         rows = _read_all(dest_url, "processed")
         assert len(rows) == 3
-        names = sorted(r["name"] for r in rows)
+        names = sorted(str(r["name"]) for r in rows)
         assert names == ["Alice", "Bob", "Charlie"]
 
 
@@ -258,6 +260,7 @@ class TestEngineProviderSharing:
                     url=dest_url, table="processed", engine_provider=provider
                 ) as writer:
                     for event in events:
+                        assert event.after is not None  # noqa: S101  # nosec B101
                         writer.upsert(
                             data={
                                 "id": event.pk["id"],
@@ -329,6 +332,7 @@ class TestCheckpointResumeAfterFailure:
             if call_count == 1:
                 with DbWriter(url=dest_url, table="processed") as writer:
                     for event in events:
+                        assert event.after is not None  # noqa: S101  # nosec B101
                         writer.insert(
                             data={
                                 "id": event.pk["id"],
@@ -359,6 +363,7 @@ class TestCheckpointResumeAfterFailure:
         def handler(events: list[RowChange]) -> None:
             with DbWriter(url=dest_url, table="processed") as writer:
                 for event in events:
+                    assert event.after is not None  # noqa: S101  # nosec B101
                     writer.upsert(
                         data={
                             "id": event.pk["id"],
@@ -415,14 +420,16 @@ class TestUpsertManyBatchIntegration:
         )
 
         def handler(events: list[RowChange]) -> None:
-            rows = [
-                {
-                    "id": event.pk["id"],
-                    "name": event.after["name"],
-                    "cursor_val": event.cursor,
-                }
-                for event in events
-            ]
+            rows: list[dict[str, object]] = []
+            for event in events:
+                assert event.after is not None  # noqa: S101  # nosec B101
+                rows.append(
+                    {
+                        "id": event.pk["id"],
+                        "name": event.after["name"],
+                        "cursor_val": event.cursor,
+                    }
+                )
             if rows:
                 with DbWriter(url=dest_url, table="processed") as writer:
                     writer.upsert_many(rows=rows, conflict_columns=["id"])

--- a/tests/test_binding_integration.py
+++ b/tests/test_binding_integration.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine, insert, select
+
+from azure_functions_db.adapter.sqlalchemy import SqlAlchemySource
+from azure_functions_db.binding.reader import DbReader
+from azure_functions_db.binding.writer import DbWriter
+from azure_functions_db.core.config import DbConfig
+from azure_functions_db.core.engine import EngineProvider
+from azure_functions_db.trigger.events import RowChange
+from azure_functions_db.trigger.poll import PollTrigger
+
+
+class FakeStateStore:
+    def __init__(self) -> None:
+        self.checkpoints: dict[str, dict[str, object]] = {}
+        self.leases: dict[str, str] = {}
+        self.lease_counter = 0
+        self.commit_error: Exception | None = None
+
+    def acquire_lease(self, poller_name: str, ttl_seconds: int) -> str:
+        del ttl_seconds
+        self.lease_counter += 1
+        lease_id = f"lease-{self.lease_counter}"
+        self.leases[poller_name] = lease_id
+        return lease_id
+
+    def renew_lease(self, poller_name: str, lease_id: str, ttl_seconds: int) -> None:
+        del poller_name, lease_id, ttl_seconds
+
+    def release_lease(self, poller_name: str, lease_id: str) -> None:
+        del lease_id
+        self.leases.pop(poller_name, None)
+
+    def load_checkpoint(self, poller_name: str) -> dict[str, object]:
+        return self.checkpoints.get(poller_name, {})
+
+    def commit_checkpoint(
+        self, poller_name: str, checkpoint: dict[str, object], lease_id: str
+    ) -> None:
+        del lease_id
+        if self.commit_error is not None:
+            raise self.commit_error
+        self.checkpoints[poller_name] = checkpoint
+
+
+def _create_source_db(db_path: Path) -> str:
+    url = f"sqlite:///{db_path}"
+    engine = create_engine(url)
+    metadata = MetaData()
+    Table(
+        "orders",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String(50)),
+        Column("updated_at", Integer),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            insert(metadata.tables["orders"]),
+            [
+                {"id": 1, "name": "Alice", "updated_at": 100},
+                {"id": 2, "name": "Bob", "updated_at": 200},
+                {"id": 3, "name": "Charlie", "updated_at": 300},
+            ],
+        )
+    engine.dispose()
+    return url
+
+
+def _create_dest_db(db_path: Path) -> str:
+    url = f"sqlite:///{db_path}"
+    engine = create_engine(url)
+    metadata = MetaData()
+    Table(
+        "processed",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String(50)),
+        Column("cursor_val", Integer),
+    )
+    metadata.create_all(engine)
+    engine.dispose()
+    return url
+
+
+def _read_all(url: str, table_name: str) -> list[dict[str, object]]:
+    engine = create_engine(url)
+    metadata = MetaData()
+    metadata.reflect(bind=engine, only=[table_name])
+    tbl = metadata.tables[table_name]
+    with engine.connect() as conn:
+        result = conn.execute(select(tbl))
+        rows = [dict(row._mapping) for row in result]
+    engine.dispose()
+    return rows
+
+
+@pytest.fixture()
+def source_url(tmp_path: Path) -> str:
+    return _create_source_db(tmp_path / "source.db")
+
+
+@pytest.fixture()
+def dest_url(tmp_path: Path) -> str:
+    return _create_dest_db(tmp_path / "dest.db")
+
+
+class TestTriggerWithWriter:
+    def test_trigger_detects_changes_and_writes_to_dest(
+        self, source_url: str, dest_url: str
+    ) -> None:
+        source = SqlAlchemySource(
+            url=source_url,
+            table="orders",
+            cursor_column="updated_at",
+            pk_columns=["id"],
+        )
+        state_store = FakeStateStore()
+        trigger = PollTrigger(
+            name="orders_integ",
+            source=source,
+            checkpoint_store=state_store,
+            batch_size=100,
+        )
+
+        def handler(events: list[RowChange]) -> None:
+            with DbWriter(url=dest_url, table="processed") as writer:
+                for event in events:
+                    writer.insert(
+                        data={
+                            "id": event.pk["id"],
+                            "name": event.after["name"],
+                            "cursor_val": event.cursor,
+                        }
+                    )
+
+        count = trigger.run(timer=object(), handler=handler)
+
+        assert count == 3
+        rows = _read_all(dest_url, "processed")
+        assert len(rows) == 3
+        by_id = {r["id"]: r for r in rows}
+        assert by_id[1]["name"] == "Alice"
+        assert by_id[2]["name"] == "Bob"
+        assert by_id[3]["name"] == "Charlie"
+
+    def test_second_tick_with_checkpoint_is_noop(
+        self, source_url: str, dest_url: str
+    ) -> None:
+        source = SqlAlchemySource(
+            url=source_url,
+            table="orders",
+            cursor_column="updated_at",
+            pk_columns=["id"],
+        )
+        state_store = FakeStateStore()
+        trigger = PollTrigger(
+            name="orders_integ",
+            source=source,
+            checkpoint_store=state_store,
+            batch_size=100,
+        )
+
+        def handler(events: list[RowChange]) -> None:
+            with DbWriter(url=dest_url, table="processed") as writer:
+                for event in events:
+                    writer.upsert(
+                        data={
+                            "id": event.pk["id"],
+                            "name": event.after["name"],
+                            "cursor_val": event.cursor,
+                        },
+                        conflict_columns=["id"],
+                    )
+
+        first_count = trigger.run(timer=object(), handler=handler)
+        assert first_count == 3
+
+        second_count = trigger.run(timer=object(), handler=handler)
+        assert second_count == 0
+
+        rows = _read_all(dest_url, "processed")
+        assert len(rows) == 3
+
+
+class TestTriggerWithReaderAndWriter:
+    def test_trigger_reads_enriched_data_and_writes(
+        self, source_url: str, dest_url: str
+    ) -> None:
+        source = SqlAlchemySource(
+            url=source_url,
+            table="orders",
+            cursor_column="updated_at",
+            pk_columns=["id"],
+        )
+        state_store = FakeStateStore()
+        trigger = PollTrigger(
+            name="orders_enrich",
+            source=source,
+            checkpoint_store=state_store,
+            batch_size=100,
+        )
+
+        def handler(events: list[RowChange]) -> None:
+            reader = DbReader(url=source_url, table="orders")
+            writer = DbWriter(url=dest_url, table="processed")
+            try:
+                for event in events:
+                    row = reader.get(pk={"id": event.pk["id"]})
+                    if row is not None:
+                        writer.insert(
+                            data={
+                                "id": row["id"],
+                                "name": row["name"],
+                                "cursor_val": event.cursor,
+                            }
+                        )
+            finally:
+                reader.close()
+                writer.close()
+
+        count = trigger.run(timer=object(), handler=handler)
+
+        assert count == 3
+        rows = _read_all(dest_url, "processed")
+        assert len(rows) == 3
+        names = sorted(r["name"] for r in rows)
+        assert names == ["Alice", "Bob", "Charlie"]
+
+
+class TestEngineProviderSharing:
+    def test_shared_engine_provider_across_reader_and_writer(
+        self, source_url: str, dest_url: str
+    ) -> None:
+        provider = EngineProvider()
+        try:
+            source = SqlAlchemySource(
+                url=source_url,
+                table="orders",
+                cursor_column="updated_at",
+                pk_columns=["id"],
+                engine_provider=provider,
+            )
+            state_store = FakeStateStore()
+            trigger = PollTrigger(
+                name="shared_engine",
+                source=source,
+                checkpoint_store=state_store,
+                batch_size=100,
+            )
+
+            def handler(events: list[RowChange]) -> None:
+                with DbWriter(
+                    url=dest_url, table="processed", engine_provider=provider
+                ) as writer:
+                    for event in events:
+                        writer.upsert(
+                            data={
+                                "id": event.pk["id"],
+                                "name": event.after["name"],
+                                "cursor_val": event.cursor,
+                            },
+                            conflict_columns=["id"],
+                        )
+
+            count = trigger.run(timer=object(), handler=handler)
+
+            assert count == 3
+            rows = _read_all(dest_url, "processed")
+            assert len(rows) == 3
+        finally:
+            provider.dispose_all()
+
+    def test_reader_and_writer_same_db_shared_provider(
+        self, source_url: str
+    ) -> None:
+        provider = EngineProvider()
+        try:
+            with DbReader(
+                url=source_url, table="orders", engine_provider=provider
+            ) as reader:
+                row = reader.get(pk={"id": 1})
+                assert row is not None
+                assert row["name"] == "Alice"
+
+            dest_url = source_url
+            with DbWriter(
+                url=dest_url, table="orders", engine_provider=provider
+            ) as writer:
+                writer.update(data={"name": "Alice Updated"}, pk={"id": 1})
+
+            with DbReader(
+                url=source_url, table="orders", engine_provider=provider
+            ) as reader:
+                row = reader.get(pk={"id": 1})
+                assert row is not None
+                assert row["name"] == "Alice Updated"
+        finally:
+            provider.dispose_all()
+
+
+class TestCheckpointResumeAfterFailure:
+    def test_handler_failure_does_not_commit_checkpoint(
+        self, source_url: str, dest_url: str
+    ) -> None:
+        source = SqlAlchemySource(
+            url=source_url,
+            table="orders",
+            cursor_column="updated_at",
+            pk_columns=["id"],
+        )
+        state_store = FakeStateStore()
+        trigger = PollTrigger(
+            name="fail_resume",
+            source=source,
+            checkpoint_store=state_store,
+            batch_size=100,
+        )
+
+        call_count = 0
+
+        def handler(events: list[RowChange]) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                with DbWriter(url=dest_url, table="processed") as writer:
+                    for event in events:
+                        writer.insert(
+                            data={
+                                "id": event.pk["id"],
+                                "name": event.after["name"],
+                                "cursor_val": event.cursor,
+                            }
+                        )
+                raise RuntimeError("Simulated handler failure")
+
+        from azure_functions_db.trigger.errors import HandlerError
+
+        with pytest.raises(HandlerError):
+            trigger.run(timer=object(), handler=handler)
+
+        assert "fail_resume" not in state_store.checkpoints
+
+    def test_retry_with_upsert_is_idempotent(
+        self, source_url: str, dest_url: str
+    ) -> None:
+        source = SqlAlchemySource(
+            url=source_url,
+            table="orders",
+            cursor_column="updated_at",
+            pk_columns=["id"],
+        )
+        state_store = FakeStateStore()
+
+        def handler(events: list[RowChange]) -> None:
+            with DbWriter(url=dest_url, table="processed") as writer:
+                for event in events:
+                    writer.upsert(
+                        data={
+                            "id": event.pk["id"],
+                            "name": event.after["name"],
+                            "cursor_val": event.cursor,
+                        },
+                        conflict_columns=["id"],
+                    )
+
+        trigger1 = PollTrigger(
+            name="idempotent_test",
+            source=source,
+            checkpoint_store=state_store,
+            batch_size=100,
+        )
+        count1 = trigger1.run(timer=object(), handler=handler)
+        assert count1 == 3
+
+        state_store.checkpoints.clear()
+
+        trigger2 = PollTrigger(
+            name="idempotent_test",
+            source=source,
+            checkpoint_store=state_store,
+            batch_size=100,
+        )
+        count2 = trigger2.run(timer=object(), handler=handler)
+        assert count2 == 3
+
+        rows = _read_all(dest_url, "processed")
+        assert len(rows) == 3
+        by_id = {r["id"]: r for r in rows}
+        assert by_id[1]["name"] == "Alice"
+        assert by_id[2]["name"] == "Bob"
+        assert by_id[3]["name"] == "Charlie"
+
+
+class TestUpsertManyBatchIntegration:
+    def test_trigger_with_batch_upsert(
+        self, source_url: str, dest_url: str
+    ) -> None:
+        source = SqlAlchemySource(
+            url=source_url,
+            table="orders",
+            cursor_column="updated_at",
+            pk_columns=["id"],
+        )
+        state_store = FakeStateStore()
+        trigger = PollTrigger(
+            name="batch_upsert",
+            source=source,
+            checkpoint_store=state_store,
+            batch_size=100,
+        )
+
+        def handler(events: list[RowChange]) -> None:
+            rows = [
+                {
+                    "id": event.pk["id"],
+                    "name": event.after["name"],
+                    "cursor_val": event.cursor,
+                }
+                for event in events
+            ]
+            if rows:
+                with DbWriter(url=dest_url, table="processed") as writer:
+                    writer.upsert_many(rows=rows, conflict_columns=["id"])
+
+        count = trigger.run(timer=object(), handler=handler)
+
+        assert count == 3
+        rows = _read_all(dest_url, "processed")
+        assert len(rows) == 3

--- a/tests/test_binding_integration.py
+++ b/tests/test_binding_integration.py
@@ -80,7 +80,7 @@ def _create_dest_db(db_path: Path) -> str:
         metadata,
         Column("id", Integer, primary_key=True),
         Column("name", String(50)),
-        Column("cursor_val", Integer),
+        Column("cursor_val", String(100)),
     )
     metadata.create_all(engine)
     engine.dispose()
@@ -130,16 +130,19 @@ class TestTriggerWithWriter:
         def handler(events: list[RowChange]) -> None:
             with DbWriter(url=dest_url, table="processed") as writer:
                 for event in events:
-                    assert event.after is not None  # noqa: S101  # nosec B101
+                    assert event.after is not None
                     writer.insert(
                         data={
                             "id": event.pk["id"],
                             "name": event.after["name"],
-                            "cursor_val": event.cursor,
+                            "cursor_val": str(event.cursor),
                         }
                     )
 
-        count = trigger.run(timer=object(), handler=handler)
+        try:
+            count = trigger.run(timer=object(), handler=handler)
+        finally:
+            source.dispose()
 
         assert count == 3
         rows = _read_all(dest_url, "processed")
@@ -169,21 +172,24 @@ class TestTriggerWithWriter:
         def handler(events: list[RowChange]) -> None:
             with DbWriter(url=dest_url, table="processed") as writer:
                 for event in events:
-                    assert event.after is not None  # noqa: S101  # nosec B101
+                    assert event.after is not None
                     writer.upsert(
                         data={
                             "id": event.pk["id"],
                             "name": event.after["name"],
-                            "cursor_val": event.cursor,
+                            "cursor_val": str(event.cursor),
                         },
                         conflict_columns=["id"],
                     )
 
-        first_count = trigger.run(timer=object(), handler=handler)
-        assert first_count == 3
+        try:
+            first_count = trigger.run(timer=object(), handler=handler)
+            assert first_count == 3
 
-        second_count = trigger.run(timer=object(), handler=handler)
-        assert second_count == 0
+            second_count = trigger.run(timer=object(), handler=handler)
+            assert second_count == 0
+        finally:
+            source.dispose()
 
         rows = _read_all(dest_url, "processed")
         assert len(rows) == 3
@@ -218,14 +224,17 @@ class TestTriggerWithReaderAndWriter:
                             data={
                                 "id": row["id"],
                                 "name": row["name"],
-                                "cursor_val": event.cursor,
+                                "cursor_val": str(event.cursor),
                             }
                         )
             finally:
                 reader.close()
                 writer.close()
 
-        count = trigger.run(timer=object(), handler=handler)
+        try:
+            count = trigger.run(timer=object(), handler=handler)
+        finally:
+            source.dispose()
 
         assert count == 3
         rows = _read_all(dest_url, "processed")
@@ -260,12 +269,12 @@ class TestEngineProviderSharing:
                     url=dest_url, table="processed", engine_provider=provider
                 ) as writer:
                     for event in events:
-                        assert event.after is not None  # noqa: S101  # nosec B101
+                        assert event.after is not None
                         writer.upsert(
                             data={
                                 "id": event.pk["id"],
                                 "name": event.after["name"],
-                                "cursor_val": event.cursor,
+                                "cursor_val": str(event.cursor),
                             },
                             conflict_columns=["id"],
                         )
@@ -332,22 +341,96 @@ class TestCheckpointResumeAfterFailure:
             if call_count == 1:
                 with DbWriter(url=dest_url, table="processed") as writer:
                     for event in events:
-                        assert event.after is not None  # noqa: S101  # nosec B101
+                        assert event.after is not None
                         writer.insert(
                             data={
                                 "id": event.pk["id"],
                                 "name": event.after["name"],
-                                "cursor_val": event.cursor,
+                                "cursor_val": str(event.cursor),
                             }
                         )
                 raise RuntimeError("Simulated handler failure")
 
         from azure_functions_db.trigger.errors import HandlerError
 
-        with pytest.raises(HandlerError):
-            trigger.run(timer=object(), handler=handler)
+        try:
+            with pytest.raises(HandlerError):
+                trigger.run(timer=object(), handler=handler)
+        finally:
+            source.dispose()
 
         assert "fail_resume" not in state_store.checkpoints
+
+    def test_commit_failure_preserves_writes_and_allows_retry(
+        self, source_url: str, dest_url: str
+    ) -> None:
+        """Test at-least-once: writes succeed but checkpoint commit fails.
+
+        The handler writes via upsert, but checkpoint commit raises an error.
+        On retry (after clearing the error), the same rows are upserted again
+        idempotently, resulting in no duplicates.
+        """
+        source = SqlAlchemySource(
+            url=source_url,
+            table="orders",
+            cursor_column="updated_at",
+            pk_columns=["id"],
+        )
+        state_store = FakeStateStore()
+
+        def handler(events: list[RowChange]) -> None:
+            with DbWriter(url=dest_url, table="processed") as writer:
+                for event in events:
+                    assert event.after is not None
+                    writer.upsert(
+                        data={
+                            "id": event.pk["id"],
+                            "name": event.after["name"],
+                            "cursor_val": str(event.cursor),
+                        },
+                        conflict_columns=["id"],
+                    )
+
+        # First run: writes succeed but checkpoint commit fails
+        state_store.commit_error = RuntimeError("Checkpoint commit failure")
+        trigger1 = PollTrigger(
+            name="commit_fail",
+            source=source,
+            checkpoint_store=state_store,
+            batch_size=100,
+        )
+
+        try:
+            # The commit error should propagate (not silently swallowed)
+            with pytest.raises(Exception):  # noqa: B017, PT011
+                trigger1.run(timer=object(), handler=handler)
+
+            # Checkpoint was NOT persisted
+            assert "commit_fail" not in state_store.checkpoints
+
+            # But writes DID land in the destination
+            rows = _read_all(dest_url, "processed")
+            assert len(rows) == 3
+
+            # Retry: clear the error, run again — upsert is idempotent
+            state_store.commit_error = None
+            trigger2 = PollTrigger(
+                name="commit_fail",
+                source=source,
+                checkpoint_store=state_store,
+                batch_size=100,
+            )
+            count = trigger2.run(timer=object(), handler=handler)
+            assert count == 3
+
+            # Still exactly 3 rows (no duplicates)
+            rows = _read_all(dest_url, "processed")
+            assert len(rows) == 3
+
+            # Checkpoint is now persisted
+            assert "commit_fail" in state_store.checkpoints
+        finally:
+            source.dispose()
 
     def test_retry_with_upsert_is_idempotent(
         self, source_url: str, dest_url: str
@@ -363,12 +446,12 @@ class TestCheckpointResumeAfterFailure:
         def handler(events: list[RowChange]) -> None:
             with DbWriter(url=dest_url, table="processed") as writer:
                 for event in events:
-                    assert event.after is not None  # noqa: S101  # nosec B101
+                    assert event.after is not None
                     writer.upsert(
                         data={
                             "id": event.pk["id"],
                             "name": event.after["name"],
-                            "cursor_val": event.cursor,
+                            "cursor_val": str(event.cursor),
                         },
                         conflict_columns=["id"],
                     )
@@ -379,19 +462,23 @@ class TestCheckpointResumeAfterFailure:
             checkpoint_store=state_store,
             batch_size=100,
         )
-        count1 = trigger1.run(timer=object(), handler=handler)
-        assert count1 == 3
 
-        state_store.checkpoints.clear()
+        try:
+            count1 = trigger1.run(timer=object(), handler=handler)
+            assert count1 == 3
 
-        trigger2 = PollTrigger(
-            name="idempotent_test",
-            source=source,
-            checkpoint_store=state_store,
-            batch_size=100,
-        )
-        count2 = trigger2.run(timer=object(), handler=handler)
-        assert count2 == 3
+            state_store.checkpoints.clear()
+
+            trigger2 = PollTrigger(
+                name="idempotent_test",
+                source=source,
+                checkpoint_store=state_store,
+                batch_size=100,
+            )
+            count2 = trigger2.run(timer=object(), handler=handler)
+            assert count2 == 3
+        finally:
+            source.dispose()
 
         rows = _read_all(dest_url, "processed")
         assert len(rows) == 3
@@ -422,19 +509,22 @@ class TestUpsertManyBatchIntegration:
         def handler(events: list[RowChange]) -> None:
             rows: list[dict[str, object]] = []
             for event in events:
-                assert event.after is not None  # noqa: S101  # nosec B101
+                assert event.after is not None
                 rows.append(
                     {
                         "id": event.pk["id"],
                         "name": event.after["name"],
-                        "cursor_val": event.cursor,
+                        "cursor_val": str(event.cursor),
                     }
                 )
             if rows:
                 with DbWriter(url=dest_url, table="processed") as writer:
                     writer.upsert_many(rows=rows, conflict_columns=["id"])
 
-        count = trigger.run(timer=object(), handler=handler)
+        try:
+            count = trigger.run(timer=object(), handler=handler)
+        finally:
+            source.dispose()
 
         assert count == 3
         rows = _read_all(dest_url, "processed")

--- a/tests/test_binding_integration.py
+++ b/tests/test_binding_integration.py
@@ -8,7 +8,6 @@ from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine, 
 from azure_functions_db.adapter.sqlalchemy import SqlAlchemySource
 from azure_functions_db.binding.reader import DbReader
 from azure_functions_db.binding.writer import DbWriter
-from azure_functions_db.core.config import DbConfig
 from azure_functions_db.core.engine import EngineProvider
 from azure_functions_db.trigger.events import RowChange
 from azure_functions_db.trigger.poll import PollTrigger


### PR DESCRIPTION
## Summary
- End-to-end integration tests proving trigger + reader + writer composition
- Runnable example demonstrating combined usage with EngineProvider sharing
- README and docs updates

## Integration Test Scenarios
1. **Trigger → Writer**: Detect DB changes, write processed rows to destination
2. **Checkpoint resume**: Second tick after checkpoint is a no-op (no duplicates)
3. **Trigger → Reader → Writer**: Enrich data via DbReader before writing
4. **EngineProvider sharing**: Shared connection pooling across trigger, reader, writer
5. **Handler failure**: RuntimeError in handler prevents checkpoint commit
6. **Upsert idempotency**: Cleared checkpoint + re-run produces no duplicates via upsert
7. **Batch upsert_many**: End-to-end with upsert_many in handler

## Changes
- `tests/test_binding_integration.py` — 7 integration tests (~435 lines)
- `examples/trigger_with_binding/function_app.py` — runnable sample
- `README.md` — "Combined: Trigger + Binding" section added
- `docs/21-dev-checklist.md` — Phase 11 items checked off

Closes #15