### PR TITLE
fix: add kw_only=True to RetryPolicy and create mkdocs.yml

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,7 @@
+# API Reference
+
+::: azure_functions_db
+    options:
+      show_root_heading: true
+      show_root_full_path: false
+      members_order: source

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,31 @@
+# Azure Functions DB
+
+Unified DB integration (trigger + input/output binding) for Azure Functions Python v2.
+
+## Features
+
+- **DB Change Detection (Trigger)**: Poll-based pseudo trigger that detects new/changed rows via cursor tracking
+- **Input Binding (DbReader)**: Read rows from any SQLAlchemy-supported database
+- **Output Binding (DbWriter)**: Write, upsert, update, and delete rows
+- **SQLAlchemy-powered**: Works with PostgreSQL, MySQL, SQLite, and MSSQL
+- **Azure Functions v2 native**: Integrates with the Python v2 programming model
+
+## Quick Start
+
+```bash
+pip install azure-functions-db[postgres]
+```
+
+```python
+from azure_functions_db import PollTrigger, DbReader, DbWriter
+from azure_functions_db import DbConfig, SqlAlchemySource
+```
+
+For detailed usage, see the [Python API Spec](04-python-api-spec.md).
+
+## Documentation
+
+- [Project Overview](00-project-overview.md)
+- [Architecture](02-architecture.md)
+- [Binding Semantics](22-binding-semantics.md)
+- [API Reference](api.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,81 @@
+site_name: Azure Functions DB
+site_description: Unified DB integration (trigger + input/output binding) for Azure Functions Python v2
+site_author: Yeongseon Choe
+repo_url: https://github.com/yeongseon/azure-functions-db
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Project Overview: 00-project-overview.md
+      - PRD: 01-PRD.md
+      - Architecture: 02-architecture.md
+      - Semantics: 03-semantics.md
+  - User Guide:
+      - Python API Spec: 04-python-api-spec.md
+      - Adapter SDK: 05-adapter-sdk.md
+      - Checkpoint & Lease: 06-checkpoint-lease-spec.md
+      - Event Model: 07-event-model.md
+      - Binding Semantics: 22-binding-semantics.md
+  - Development:
+      - Repository Structure: 08-repo-structure.md
+      - Local Dev Guide: 09-local-dev-guide.md
+      - Test Strategy: 10-test-strategy.md
+      - Observability: 11-observability.md
+      - Security: 12-security.md
+      - Deployment Guide: 13-deployment-guide.md
+      - Dev Checklist: 21-dev-checklist.md
+      - Contributing: 15-CONTRIBUTING.md
+  - Architecture Decision Records:
+      - ADR-001 Pseudo Trigger: 16-ADR-001-pseudo-trigger-over-native.md
+      - ADR-002 SQLAlchemy Adapter: 17-ADR-002-sqlalchemy-centric-adapter.md
+      - ADR-003 Blob Checkpoint MVP: 18-ADR-003-blob-checkpoint-mvp.md
+      - ADR-004 At-Least-Once Default: 19-ADR-004-at-least-once-default.md
+      - ADR-005 Unified Package: 23-ADR-005-unified-package-design.md
+  - Reference:
+      - Roadmap: 14-roadmap.md
+      - Open Issues: 20-open-issues.md
+      - References: 99-references.md
+      - Release Process: release_process.md
+  - API Reference: api.md
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+      toc_depth: 3
+  - tables
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - pymdownx.inlinehilite
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            show_signature: true
+            show_root_full_path: false
+            merge_init_into_class: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/yeongseon/azure-functions-db
+  copyright: |
+    © 2026 Yeongseon Choe – MIT Licensed

--- a/src/azure_functions_db/trigger/retry.py
+++ b/src/azure_functions_db/trigger/retry.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class RetryPolicy:
     max_retries: int = 3
     base_delay_seconds: float = 1.0


### PR DESCRIPTION
## Summary

- Add `kw_only=True` to `RetryPolicy` dataclass to match project-wide convention (all dataclasses use `kw_only=True`)
- Create `mkdocs.yml` with full navigation structure for all 26 design docs
- Add `docs/index.md` landing page and `docs/api.md` for mkdocstrings API reference
- Fixes the failing `Deploy MkDocs to GitHub Pages` workflow on main

## Changes

- `src/azure_functions_db/trigger/retry.py`: Added `kw_only=True` to `@dataclass` decorator
- `mkdocs.yml`: New file — MkDocs configuration adapted from `azure-functions-openapi` reference project
- `docs/index.md`: New file — Documentation landing page
- `docs/api.md`: New file — API reference page using mkdocstrings

## Context

Final verification by Oracle identified these as remaining issues before the project can be considered fully complete.