### PR TITLE
fix(docs): replace relative parent links with GitHub URLs for strict mkdocs

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -58,7 +58,7 @@ Each command will:
 
 Tag push automatically triggers the CI/CD workflows listed above.
 
-> **Important**: After bumping the version, update `tests/test_public_api.py` to match the new version string. See [AGENTS.md](../AGENTS.md) for details.
+> **Important**: After bumping the version, update `tests/test_public_api.py` to match the new version string. See [AGENTS.md](https://github.com/yeongseon/azure-functions-db/blob/main/AGENTS.md) for details.
 
 > Make sure your `main` branch is up-to-date before running these commands.
 
@@ -156,5 +156,5 @@ pip install --index-url https://test.pypi.org/simple/ azure-functions-db
 ## Related
 
 - [CHANGELOG.md](https://github.com/yeongseon/azure-functions-db/blob/main/CHANGELOG.md)
-- [AGENTS.md](../AGENTS.md) — release flow and version update rules
-- [Contributing](../CONTRIBUTING.md)
+- [AGENTS.md](https://github.com/yeongseon/azure-functions-db/blob/main/AGENTS.md) — release flow and version update rules
+- [Contributing](https://github.com/yeongseon/azure-functions-db/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
## Summary

- Replace `../AGENTS.md` and `../CONTRIBUTING.md` relative links in `docs/release_process.md` with absolute GitHub URLs
- Fixes the `Deploy MkDocs to GitHub Pages` workflow failing in strict mode (`mkdocs build --strict` aborts on warnings for unresolvable parent-directory links)

## Changes

- `docs/release_process.md`: 3 links updated from `../` relative paths to `https://github.com/yeongseon/azure-functions-db/blob/main/` URLs

## Context

These files (`AGENTS.md`, `CONTRIBUTING.md`) live at the repo root, outside the `docs/` directory. MkDocs cannot resolve relative paths that escape the docs directory, causing strict mode to abort with warnings.