### PR TITLE
feat(decorator): redesign API to DbFunctionApp with db_trigger, db_input, db_output

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ azure-functions-db[postgres]
 ```python
 import azure.functions as func
 from azure.storage.blob import ContainerClient
-from azure_functions_db import BlobCheckpointStore, PollTrigger, RowChange, SqlAlchemySource
+from azure_functions_db import BlobCheckpointStore, DbFunctionApp, RowChange, SqlAlchemySource
 
 app = func.FunctionApp()
+db = DbFunctionApp()
 
 source = SqlAlchemySource(
     url="%ORDERS_DB_URL%",
@@ -78,29 +79,20 @@ source = SqlAlchemySource(
     pk_columns=["id"],
 )
 
-trigger = PollTrigger(
-    name="orders",
-    source=source,
-    checkpoint_store=BlobCheckpointStore(
-        container_client=ContainerClient.from_connection_string(
-            conn_str="%AzureWebJobsStorage%",
-            container_name="db-state",
-        ),
-        source_fingerprint=source.source_descriptor.fingerprint,
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str="%AzureWebJobsStorage%",
+        container_name="db-state",
     ),
-    batch_size=100,
+    source_fingerprint=source.source_descriptor.fingerprint,
 )
-
-
-def handle_orders(events: list[RowChange]) -> None:
-    for event in events:
-        print(f"Order {event.pk}: {event.op}")
-
 
 @app.function_name(name="orders_poll")
 @app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
-def orders_poll(timer: func.TimerRequest) -> None:
-    trigger.run(timer=timer, handler=handle_orders)
+@db.db_trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+def orders_poll(timer: func.TimerRequest, events: list[RowChange]) -> None:
+    for event in events:
+        print(f"Order {event.pk}: {event.op}")
 ```
 
 > See [Python API Spec](docs/04-python-api-spec.md) for the full API reference.
@@ -108,45 +100,43 @@ def orders_poll(timer: func.TimerRequest) -> None:
 ### Input Binding (DbReader)
 
 ```python
-from azure_functions_db import DbReader
+from azure_functions_db import DbFunctionApp, DbReader
 
-# Look up a single row by primary key
-reader = DbReader(url="%DB_URL%", table="users")
-try:
+db = DbFunctionApp()
+
+@db.db_input("reader", url="%DB_URL%", table="users")
+def load_user(reader: DbReader) -> None:
     user = reader.get(pk={"id": 42})
     if user:
         print(user["name"])
-finally:
-    reader.close()
 
-# Raw SQL queries
-with DbReader(url="%DB_URL%") as reader:
+@db.db_input("reader", url="%DB_URL%")
+def list_active_users(reader: DbReader) -> None:
     active_users = reader.query(
         "SELECT * FROM users WHERE active = :active",
         params={"active": True},
     )
-    for u in active_users:
-        print(u["email"])
+    for user in active_users:
+        print(user["email"])
 ```
 
 ### Output Binding (DbWriter)
 
 ```python
-from azure_functions_db import DbWriter
+from azure_functions_db import DbFunctionApp, DbWriter
 
-# Insert a single row
-with DbWriter(url="%DB_URL%", table="orders") as writer:
+db = DbFunctionApp()
+
+@db.db_output("writer", url="%DB_URL%", table="orders")
+def write_orders(writer: DbWriter) -> None:
     writer.insert(data={"id": 1, "status": "pending", "total": 99.99})
-
-# Upsert (insert or update on conflict)
-with DbWriter(url="%DB_URL%", table="orders") as writer:
     writer.upsert(
         data={"id": 1, "status": "shipped", "total": 99.99},
         conflict_columns=["id"],
     )
 
-# Batch operations (all-or-nothing transaction)
-with DbWriter(url="%DB_URL%", table="orders") as writer:
+@db.db_output("writer", url="%DB_URL%", table="orders")
+def write_order_batch(writer: DbWriter) -> None:
     writer.insert_many(rows=[
         {"id": 2, "status": "pending", "total": 49.99},
         {"id": 3, "status": "pending", "total": 29.99},
@@ -160,11 +150,20 @@ Supported upsert dialects: PostgreSQL, SQLite, MySQL.
 Process database changes and write results to another table. Uses `EngineProvider` for shared connection pooling.
 
 ```python
+import azure.functions as func
 from azure.storage.blob import ContainerClient
 
 from azure_functions_db import (
-    BlobCheckpointStore, DbWriter, EngineProvider, PollTrigger, SqlAlchemySource,
+    BlobCheckpointStore,
+    DbFunctionApp,
+    DbWriter,
+    EngineProvider,
+    RowChange,
+    SqlAlchemySource,
 )
+
+app = func.FunctionApp()
+db = DbFunctionApp()
 
 engine_provider = EngineProvider()
 
@@ -176,36 +175,34 @@ source = SqlAlchemySource(
     engine_provider=engine_provider,
 )
 
-trigger = PollTrigger(
-    name="orders",
-    source=source,
-    checkpoint_store=BlobCheckpointStore(
-        container_client=ContainerClient.from_connection_string(
-            conn_str="%AzureWebJobsStorage%",
-            container_name="db-state",
-        ),
-        source_fingerprint=source.source_descriptor.fingerprint,
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str="%AzureWebJobsStorage%",
+        container_name="db-state",
     ),
+    source_fingerprint=source.source_descriptor.fingerprint,
 )
 
-def process_orders(events):
-    with DbWriter(
-        url="%DEST_DB_URL%", table="processed_orders",
-        engine_provider=engine_provider,
-    ) as writer:
-        for event in events:
-            if event.after is not None:
-                writer.upsert(
-                    data={
-                        "order_id": event.pk["id"],
-                        "customer": event.after["name"],
-                        "processed_at": str(event.cursor),
-                    },
-                    conflict_columns=["order_id"],
-                )
-
-# In your Azure Function:
-# trigger.run(timer=timer, handler=process_orders)
+@app.function_name(name="orders_poll")
+@app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
+@db.db_trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+@db.db_output(
+    arg_name="writer",
+    url="%DEST_DB_URL%",
+    table="processed_orders",
+    engine_provider=engine_provider,
+)
+def orders_poll(timer: func.TimerRequest, events: list[RowChange], writer: DbWriter) -> None:
+    for event in events:
+        if event.after is not None:
+            writer.upsert(
+                data={
+                    "order_id": event.pk["id"],
+                    "customer": event.after["name"],
+                    "processed_at": str(event.cursor),
+                },
+                conflict_columns=["order_id"],
+            )
 ```
 
 See [`examples/trigger_with_binding/`](examples/trigger_with_binding/) for a complete runnable sample.

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -14,9 +14,13 @@
    - polling orchestrator, source adapter, state management, Azure Functions integration
    - consumes `core` to handle pseudo trigger execution
 3. **binding**
-   - `DbReader` (input binding)
-   - `DbWriter` (output binding)
-   - per-invocation session/connection lifecycle management
+    - `DbReader` (input binding)
+    - `DbWriter` (output binding)
+    - per-invocation session/connection lifecycle management
+4. **decorator**
+    - `DbFunctionApp` class providing Azure Functions-style decorators
+    - `db_trigger` wraps `PollTrigger`, `db_input` injects `DbReader`, `db_output` injects `DbWriter`
+    - consumes both `trigger` and `binding` modules
 
 ### 1.1 Core Layer
 
@@ -44,6 +48,7 @@ The binding layer provides an imperative API called directly from Azure Function
 
 - `trigger -> core` dependency only
 - `binding -> core` dependency only
+- `decorator -> trigger, binding, core` (thin orchestration layer)
 - Cross-import between `trigger` and `binding` is forbidden
 
 ### 1.5 Binding Execution Flow

--- a/docs/04-python-api-spec.md
+++ b/docs/04-python-api-spec.md
@@ -43,36 +43,41 @@ def handle_orders(events, context):
         print(event.pk, event.after)
 ```
 
-### 2.2 Decorator Sugar
+### 2.2 Decorator API (DbFunctionApp)
 
 ```python
 import azure.functions as func
-from azure_functions_db import BlobCheckpointStore, SqlAlchemySource, db
+from azure.storage.blob import ContainerClient
+from azure_functions_db import BlobCheckpointStore, DbFunctionApp, RowChange, SqlAlchemySource
 
 app = func.FunctionApp()
+db = DbFunctionApp()
+
+source = SqlAlchemySource(
+    url="%ORDERS_DB_URL%",
+    table="orders",
+    schema="public",
+    cursor_column="updated_at",
+    pk_columns=["id"],
+)
+
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str="%AzureWebJobsStorage%",
+        container_name="db-state",
+    ),
+    source_fingerprint=source.source_descriptor.fingerprint,
+)
 
 @app.function_name(name="orders_poll")
 @app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
-@db.poll(
-    name="orders",
-    source=SqlAlchemySource(
-        url="%ORDERS_DB_URL%",
-        table="orders",
-        schema="public",
-        cursor_column="updated_at",
-        pk_columns=["id"],
-    ),
-    checkpoint_store=BlobCheckpointStore(
-        connection="AzureWebJobsStorage",
-        container="db-state",
-    ),
-    batch_size=100,
-)
-def handle_orders(events, context):
-    ...
+@db.db_trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+def orders_poll(timer: func.TimerRequest, events: list[RowChange]) -> None:
+    for event in events:
+        print(event.pk, event.after)
 ```
 
-In the actual implementation, the decorator creates a wrapper while keeping the wrapper signature simple to avoid conflicts with Azure Functions decorators.
+The `DbFunctionApp` class provides Azure Functions-style decorators (`db_trigger`, `db_input`, `db_output`). Internally, `db_trigger` wraps `PollTrigger` and manages `__signature__` to hide injected parameters from the Azure runtime. Decorator order contract: Azure decorators outermost, db decorators closest to the function.
 
 ## 3. Core Types
 
@@ -200,11 +205,11 @@ class SerializationError(PollerError): ...
 
 ## 8. Future API
 
-- `db.outbox(...)`
-- `db.backfill(...)`
-- `db.relay(service_bus=...)`
-- `db.model(OrderModel)`
-- `db.partitioned(...)`
+- Outbox strategy support
+- Backfill mode
+- Service Bus / Event Hub relay integration
+- Pydantic model mapping for `db_trigger` events
+- Partitioned polling
 
 ## 9. API Stability Policy
 
@@ -214,7 +219,6 @@ class SerializationError(PollerError): ...
 - dynamic partitioning
 
 ### Beta
-- decorator sugar
 - Pydantic mapping
 
 ### Stable Target
@@ -223,6 +227,9 @@ class SerializationError(PollerError): ...
 - BlobCheckpointStore
 - RowChange
 - PollContext
+- DbFunctionApp (db_trigger, db_input, db_output)
+- DbReader
+- DbWriter
 
 ## 10. Binding API
 
@@ -249,6 +256,67 @@ writer.upsert_many(rows=[...], conflict_columns=["id"])
 ```
 
 ### 10.3 Combined Trigger + Binding Example
+
+Using the decorator API with `DbFunctionApp`:
+
+```python
+import azure.functions as func
+from azure.storage.blob import ContainerClient
+
+from azure_functions_db import (
+    BlobCheckpointStore,
+    DbFunctionApp,
+    DbWriter,
+    EngineProvider,
+    RowChange,
+    SqlAlchemySource,
+)
+
+app = func.FunctionApp()
+db = DbFunctionApp()
+
+engine_provider = EngineProvider()
+
+source = SqlAlchemySource(
+    url="%SOURCE_DB_URL%",
+    table="orders",
+    schema="public",
+    cursor_column="updated_at",
+    pk_columns=["id"],
+    engine_provider=engine_provider,
+)
+
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str="%AzureWebJobsStorage%",
+        container_name="db-state",
+    ),
+    source_fingerprint=source.source_descriptor.fingerprint,
+)
+
+@app.function_name(name="orders_poll")
+@app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
+@db.db_trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+@db.db_output(
+    arg_name="writer",
+    url="%DEST_DB_URL%",
+    table="processed_orders",
+    engine_provider=engine_provider,
+)
+def orders_poll(timer: func.TimerRequest, events: list[RowChange], writer: DbWriter) -> None:
+    for event in events:
+        if event.after is not None:
+            writer.upsert(
+                data={
+                    "order_id": event.pk["id"],
+                    "customer": event.after["name"],
+                    "processed_at": str(event.cursor),
+                },
+                conflict_columns=["order_id"],
+            )
+```
+
+Using the imperative API directly:
 
 ```python
 import azure.functions as func
@@ -332,6 +400,43 @@ class DbConnectionError(DbError): ...
 class QueryError(DbError): ...
 class WriteError(DbError): ...
 ```
+
+### 10.7 Decorator API for Bindings (DbFunctionApp)
+
+The `DbFunctionApp` class provides `db_input` and `db_output` decorators that inject
+`DbReader` / `DbWriter` instances per invocation with automatic lifecycle management.
+
+#### db_input (inject DbReader)
+
+```python
+from azure_functions_db import DbFunctionApp, DbReader
+
+db = DbFunctionApp()
+
+@db.db_input("reader", url="%DB_URL%", table="users")
+def load_user(reader: DbReader) -> dict[str, object] | None:
+    return reader.get(pk={"id": 42})
+
+@db.db_input("reader", url="%DB_URL%")
+def list_active(reader: DbReader) -> list[dict[str, object]]:
+    return reader.query("SELECT * FROM users WHERE active = :active", params={"active": True})
+```
+
+#### db_output (inject DbWriter)
+
+```python
+from azure_functions_db import DbFunctionApp, DbWriter
+
+db = DbFunctionApp()
+
+@db.db_output("writer", url="%DB_URL%", table="orders")
+def write_order(writer: DbWriter) -> None:
+    writer.insert(data={"id": 1, "status": "pending", "total": 99.99})
+    writer.upsert(data={"id": 1, "status": "shipped"}, conflict_columns=["id"])
+```
+
+Both decorators support sync and async handlers.  The injected instance is created
+fresh per invocation and closed automatically in a `finally` block.
 
 ## 11. Shared Core API
 

--- a/docs/07-event-model.md
+++ b/docs/07-event-model.md
@@ -127,9 +127,10 @@ class OrderChange(BaseModel):
     status: str
     updated_at: datetime
 
-@db.poll(..., model=OrderChange)
-def handle(events: list[OrderChange], context):
-    ...
+# Future: Pydantic model mapping for db_trigger events
+# @db.db_trigger(arg_name="events", source=source, checkpoint_store=store, model=OrderChange)
+# def handle(events: list[OrderChange], context):
+#     ...
 ```
 
 Note:

--- a/docs/08-repo-structure.md
+++ b/docs/08-repo-structure.md
@@ -23,7 +23,7 @@ azure-functions-db/
         context.py       # PollContext
         events.py        # RowChange, EventNormalizer
         retry.py
-        decorators.py    # @db.trigger()
+        decorators.py    # DbFunctionApp (db_trigger, db_input, db_output)
 
         state/
           __init__.py
@@ -72,8 +72,8 @@ azure-functions-db/
 
 ## Module Responsibilities
 
-### api.py
-Public re-export surface. Exposes `PollTrigger`, `SqlAlchemySource`, `BlobCheckpointStore`, `DbReader`, `DbWriter`.
+### api.py / __init__.py
+Public re-export surface. Exposes `PollTrigger`, `SqlAlchemySource`, `BlobCheckpointStore`, `DbReader`, `DbWriter`, `DbFunctionApp`.
 
 ### core/*
 Common layer providing shared configuration, engine/pool, types, errors, and serializers.

--- a/docs/14-roadmap.md
+++ b/docs/14-roadmap.md
@@ -18,7 +18,7 @@
 - CLI reset/inspect
 
 ## v0.3
-- binding decorator sugar (`@db.input`, `@db.output`)
+- ~~binding decorator sugar~~ (done: `DbFunctionApp` with `db_trigger`, `db_input`, `db_output`)
 - Mongo adapter
 - outbox helper
 - Service Bus/Event Hub relay mode

--- a/docs/21-dev-checklist.md
+++ b/docs/21-dev-checklist.md
@@ -76,6 +76,6 @@
 
 ## Phase 11: Binding Integration
 - [x] Trigger + output binding combined example
-- [ ] Binding decorator sugar (future: API redesign)
+- [x] Binding decorator sugar (DbFunctionApp: db_trigger, db_input, db_output)
 - [x] Docs update
 - [x] Sample function_app.py with binding

--- a/docs/22-binding-semantics.md
+++ b/docs/22-binding-semantics.md
@@ -97,9 +97,11 @@ Unlike triggers, they do not manage state (checkpoint/lease) and operate on a pe
 
 ## 7. Future Extensions
 
-### 7.1 Decorator Sugar (Phase 11+)
-- @db.input(), @db.output() — thin wrappers over DbReader/DbWriter
-- To be added only after the imperative API has stabilized
+### 7.1 Decorator API (DbFunctionApp)
+- `@db.db_input()` and `@db.db_output()` — decorators that inject `DbReader` / `DbWriter` per invocation
+- `@db.db_trigger()` — decorator that wraps `PollTrigger` for change detection
+- Implemented via `DbFunctionApp` class with automatic lifecycle management (create/close per invocation)
+- See [Python API Spec](04-python-api-spec.md) for full usage
 
 ### 7.2 DbSession (if needed)
 - Explicit multi-write transaction context manager

--- a/docs/23-ADR-005-unified-package-design.md
+++ b/docs/23-ADR-005-unified-package-design.md
@@ -26,7 +26,7 @@ trigger (change detection) and binding (read/write) in a single package.
 
 ### API Strategy
 - Imperative API (DbReader, DbWriter) is primary
-- Decorator sugar (@db.input, @db.output) added later as thin wrappers
+- Decorator API (`DbFunctionApp` with `db_trigger`, `db_input`, `db_output`) provides Azure Functions-native DX
 - Packages are unified; programming models are not
 
 ## Alternatives Considered

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ pip install azure-functions-db[postgres]
 ```
 
 ```python
-from azure_functions_db import PollTrigger, DbReader, DbWriter
+from azure_functions_db import DbFunctionApp, PollTrigger, DbReader, DbWriter
 from azure_functions_db import DbConfig, SqlAlchemySource
 ```
 

--- a/examples/function_app.py
+++ b/examples/function_app.py
@@ -1,27 +1,33 @@
 import azure.functions as func
+from azure.storage.blob import ContainerClient
 
-from azure_functions_db import PollTrigger, SqlAlchemySource, BlobCheckpointStore
+from azure_functions_db import BlobCheckpointStore, DbFunctionApp, RowChange, SqlAlchemySource
 
 app = func.FunctionApp()
+db = DbFunctionApp()
 
-orders_trigger = PollTrigger(
-    name="orders",
-    source=SqlAlchemySource(
-        url="%ORDERS_DB_URL%",
-        table="orders",
-        schema="public",
-        cursor_column="updated_at",
-        pk_columns=["id"],
-    ),
-    checkpoint_store=BlobCheckpointStore(
-        connection="AzureWebJobsStorage",
-        container="db-state",
-    ),
-    batch_size=100,
-    max_batches_per_tick=1,
+source = SqlAlchemySource(
+    url="%ORDERS_DB_URL%",
+    table="orders",
+    schema="public",
+    cursor_column="updated_at",
+    pk_columns=["id"],
 )
 
-def handle_orders(events, context) -> None:
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str="%AzureWebJobsStorage%",
+        container_name="db-state",
+    ),
+    source_fingerprint=source.source_descriptor.fingerprint,
+)
+
+
+@app.function_name(name="orders_poll")
+@app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
+@db.db_trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+def orders_poll(timer: func.TimerRequest, events: list[RowChange]) -> None:
+    del timer
     for event in events:
         print(
             {
@@ -31,8 +37,3 @@ def handle_orders(events, context) -> None:
                 "after": event.after,
             }
         )
-
-@app.function_name(name="orders_poll")
-@app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
-def orders_poll(timer: func.TimerRequest) -> None:
-    orders_trigger.run(timer=timer, handler=handle_orders)

--- a/examples/poll_orders/function_app.py
+++ b/examples/poll_orders/function_app.py
@@ -1,4 +1,4 @@
-"""Example: Poll orders table for changes using PollTrigger (imperative API).
+"""Example: Poll orders table for changes using DbFunctionApp decorators.
 
 Prerequisites:
     pip install azure-functions-db[postgres]
@@ -15,12 +15,12 @@ import logging
 import azure.functions as func
 from azure.storage.blob import ContainerClient
 
-from azure_functions_db import BlobCheckpointStore, PollTrigger, RowChange, SqlAlchemySource
+from azure_functions_db import BlobCheckpointStore, DbFunctionApp, RowChange, SqlAlchemySource
 
 app = func.FunctionApp()
+db = DbFunctionApp()
 logger = logging.getLogger(__name__)
 
-# ── Source: PostgreSQL orders table ──────────────────────────────────
 source = SqlAlchemySource(
     url="%ORDERS_DB_URL%",
     table="orders",
@@ -29,30 +29,20 @@ source = SqlAlchemySource(
     pk_columns=["id"],
 )
 
-# ── PollTrigger: config holder ──────────────────────────────────────
-orders_trigger = PollTrigger(
-    name="orders",
-    source=source,
-    checkpoint_store=BlobCheckpointStore(
-        container_client=ContainerClient.from_connection_string(
-            conn_str="%AzureWebJobsStorage%",
-            container_name="db-state",
-        ),
-        source_fingerprint=source.source_descriptor.fingerprint,
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str="%AzureWebJobsStorage%",
+        container_name="db-state",
     ),
-    batch_size=100,
+    source_fingerprint=source.source_descriptor.fingerprint,
 )
 
 
-# ── Handler ─────────────────────────────────────────────────────────
-def handle_orders(events: list[RowChange]) -> None:
-    for event in events:
-        logger.info("Order %s: %s -> %s", event.pk, event.op, event.after)
-
-
-# ── Azure Function (timer trigger) ─────────────────────────────────
 @app.function_name(name="orders_poll")
 @app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
-def orders_poll(timer: func.TimerRequest) -> None:
-    count = orders_trigger.run(timer=timer, handler=handle_orders)
-    logger.info("Processed %d order events", count)
+@db.db_trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+def orders_poll(timer: func.TimerRequest, events: list[RowChange]) -> None:
+    del timer
+    logger.info("Processed %d order events", len(events))
+    for event in events:
+        logger.info("Order %s: %s -> %s", event.pk, event.op, event.after)

--- a/examples/trigger_with_binding/function_app.py
+++ b/examples/trigger_with_binding/function_app.py
@@ -1,7 +1,7 @@
 """Trigger + Binding integration example.
 
-Demonstrates using PollTrigger to detect DB changes and DbWriter to write
-processed results to a destination table.  Uses EngineProvider for shared
+Demonstrates using DbFunctionApp decorators to detect DB changes and write
+processed results to a destination table. Uses EngineProvider for shared
 connection pooling across trigger and bindings.
 
 Requirements:
@@ -21,14 +21,15 @@ from azure.storage.blob import ContainerClient
 
 from azure_functions_db import (
     BlobCheckpointStore,
+    DbFunctionApp,
     DbWriter,
     EngineProvider,
-    PollTrigger,
     SqlAlchemySource,
 )
 from azure_functions_db.trigger.events import RowChange
 
 app = func.FunctionApp()
+db = DbFunctionApp()
 
 engine_provider = EngineProvider()
 
@@ -41,41 +42,34 @@ source = SqlAlchemySource(
     engine_provider=engine_provider,
 )
 
-orders_trigger = PollTrigger(
-    name="orders",
-    source=source,
-    checkpoint_store=BlobCheckpointStore(
-        container_client=ContainerClient.from_connection_string(
-            conn_str="%AzureWebJobsStorage%",
-            container_name="db-state",
-        ),
-        source_fingerprint=source.source_descriptor.fingerprint,
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str="%AzureWebJobsStorage%",
+        container_name="db-state",
     ),
-    batch_size=100,
-    max_batches_per_tick=1,
+    source_fingerprint=source.source_descriptor.fingerprint,
 )
-
-
-def process_orders(events: list[RowChange]) -> None:
-    with DbWriter(
-        url="%DEST_DB_URL%",
-        table="processed_orders",
-        engine_provider=engine_provider,
-    ) as writer:
-        for event in events:
-            if event.after is not None:
-                writer.upsert(
-                    data={
-                        "order_id": event.pk["id"],
-                        "customer_name": event.after["name"],
-                        "amount": event.after["amount"],
-                        "processed_at": str(event.cursor),
-                    },
-                    conflict_columns=["order_id"],
-                )
 
 
 @app.function_name(name="orders_poll")
 @app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
-def orders_poll(timer: func.TimerRequest) -> None:
-    orders_trigger.run(timer=timer, handler=process_orders)
+@db.db_trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+@db.db_output(
+    arg_name="writer",
+    url="%DEST_DB_URL%",
+    table="processed_orders",
+    engine_provider=engine_provider,
+)
+def orders_poll(timer: func.TimerRequest, events: list[RowChange], writer: DbWriter) -> None:
+    del timer
+    for event in events:
+        if event.after is not None:
+            writer.upsert(
+                data={
+                    "order_id": event.pk["id"],
+                    "customer_name": event.after["name"],
+                    "amount": event.after["amount"],
+                    "processed_at": str(event.cursor),
+                },
+                conflict_columns=["order_id"],
+            )

--- a/examples/usage_postgres.py
+++ b/examples/usage_postgres.py
@@ -1,23 +1,27 @@
-from azure_functions_db import PollTrigger, SqlAlchemySource, BlobCheckpointStore
+from azure.storage.blob import ContainerClient
 
-trigger = PollTrigger(
-    name="orders",
-    source=SqlAlchemySource(
-        url="postgresql+psycopg://postgres:postgres@localhost:5432/orders",
-        table="orders",
-        schema="public",
-        cursor_column="updated_at",
-        pk_columns=["id"],
-    ),
-    checkpoint_store=BlobCheckpointStore(
-        connection="AzureWebJobsStorage",
-        container="db-state",
-    ),
+from azure_functions_db import BlobCheckpointStore, DbFunctionApp, RowChange, SqlAlchemySource
+
+db = DbFunctionApp()
+
+source = SqlAlchemySource(
+    url="postgresql+psycopg://postgres:postgres@localhost:5432/orders",
+    table="orders",
+    schema="public",
+    cursor_column="updated_at",
+    pk_columns=["id"],
 )
 
-def handler(events, context):
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str="%AzureWebJobsStorage%",
+        container_name="db-state",
+    ),
+    source_fingerprint=source.source_descriptor.fingerprint,
+)
+
+
+@db.db_trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+def handler(events: list[RowChange]) -> None:
     for event in events:
         print(event.event_id, event.pk, event.after)
-
-# pseudo code
-# trigger.run(timer=fake_timer_request, handler=handler)

--- a/src/azure_functions_db/__init__.py
+++ b/src/azure_functions_db/__init__.py
@@ -26,7 +26,7 @@ from .core.types import (
     RowDict,
     SourceDescriptor,
 )
-from .decorator import db
+from .decorator import DbFunctionApp
 from .observability import (
     METRIC_BATCH_SIZE,
     METRIC_BATCHES_TOTAL,
@@ -126,7 +126,7 @@ __all__ = [
     "StateStoreError",
     "WriteError",
     "build_log_fields",
-    "db",
+    "DbFunctionApp",
     "default_normalizer",
     "make_normalizer",
 ]

--- a/src/azure_functions_db/decorator.py
+++ b/src/azure_functions_db/decorator.py
@@ -1,53 +1,321 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 import functools
+import inspect
 import logging
 from typing import Any
 
-from azure_functions_db.observability import MetricsCollector
-from azure_functions_db.trigger.normalizers import EventNormalizer
-from azure_functions_db.trigger.poll import PollTrigger
-from azure_functions_db.trigger.retry import RetryPolicy
-from azure_functions_db.trigger.runner import SourceAdapter, StateStore
+from .binding.reader import DbReader
+from .binding.writer import DbWriter
+from .core.engine import EngineProvider
+from .core.errors import ConfigurationError
+from .observability import MetricsCollector
+from .trigger.normalizers import EventNormalizer
+from .trigger.poll import PollTrigger
+from .trigger.retry import RetryPolicy
+from .trigger.runner import SourceAdapter, StateStore
 
 logger = logging.getLogger(__name__)
 
+# Parameter names reserved by Azure Functions runtime.
+_RESERVED_ARGS = frozenset({"timer", "req", "context", "msg", "input", "output"})
 
-class _DbNamespace:
-    def poll(
+
+def _validate_arg_name(arg_name: str, fn: Callable[..., Any], decorator_name: str) -> None:
+    """Validate that *arg_name* exists in *fn*'s signature and does not collide."""
+    sig = inspect.signature(fn, follow_wrapped=False)
+    if arg_name not in sig.parameters:
+        msg = (
+            f"{decorator_name} arg_name='{arg_name}' not found in "
+            f"function '{fn.__name__}' parameters"
+        )
+        raise ConfigurationError(msg)
+
+    if arg_name in _RESERVED_ARGS:
+        msg = (
+            f"{decorator_name} arg_name='{arg_name}' conflicts with Azure Functions "
+            f"reserved parameter name. Avoid: {sorted(_RESERVED_ARGS)}"
+        )
+        raise ConfigurationError(msg)
+
+
+def _build_host_signature(
+    fn: Callable[..., Any],
+    injected: set[str],
+) -> inspect.Signature:
+    """Return a signature hiding *injected* params from Azure runtime."""
+    sig = inspect.signature(fn, follow_wrapped=False)
+    params = [p for name, p in sig.parameters.items() if name not in injected]
+    return sig.replace(parameters=params)
+
+
+class DbFunctionApp:
+    """Azure Functions-style decorator API for database integration.
+
+    Provides ``db_trigger``, ``db_input``, and ``db_output`` decorator
+    methods that wrap the imperative API (PollTrigger, DbReader, DbWriter)
+    in an Azure Functions-native decorator experience.
+
+    Decorator order contract:
+        Azure decorators outermost, db decorators closest to the function::
+
+            @app.function_name(name="my_func")
+            @app.schedule(...)          # Azure trigger (outermost)
+            @db.db_trigger(...)         # db decorator (closest to fn)
+            def my_func(events): ...
+
+    Note: This is a pseudo-trigger implementation. ``db_trigger`` requires
+    an actual Azure Functions trigger (e.g. ``@app.schedule``) to fire.
+    It does not register a native Azure Functions binding.
+    """
+
+    def db_trigger(
         self,
         *,
-        name: str,
+        arg_name: str,
         source: SourceAdapter,
         checkpoint_store: StateStore,
+        name: str | None = None,
         normalizer: EventNormalizer | None = None,
         batch_size: int = 100,
         max_batches_per_tick: int = 1,
         lease_ttl_seconds: int = 120,
         retry_policy: RetryPolicy | None = None,
         metrics: MetricsCollector | None = None,
-    ) -> Callable[[Callable[..., Any]], Callable[..., int]]:
-        trigger = PollTrigger(
-            name=name,
-            source=source,
-            checkpoint_store=checkpoint_store,
-            normalizer=normalizer,
-            batch_size=batch_size,
-            max_batches_per_tick=max_batches_per_tick,
-            lease_ttl_seconds=lease_ttl_seconds,
-            retry_policy=retry_policy,
-            metrics=metrics,
-        )
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Decorator for database change detection (pseudo-trigger).
 
-        def decorator(fn: Callable[..., Any]) -> Callable[..., int]:
+        Wraps a handler function so that on each invocation it polls the
+        database source for new/changed rows and passes them to the handler.
+
+        The decorated function's ``arg_name`` parameter will receive the
+        list of :class:`RowChange` events.  An optional parameter named
+        ``context`` will receive the :class:`PollContext`.
+
+        Must be used together with an actual Azure Functions trigger
+        (e.g. ``@app.schedule(...)``).
+
+        Parameters
+        ----------
+        arg_name:
+            Name of the handler parameter that receives the events list.
+        source:
+            Database source adapter (e.g. ``SqlAlchemySource``).
+        checkpoint_store:
+            State store for checkpointing (e.g. ``BlobCheckpointStore``).
+        name:
+            Trigger name for logging/metrics.  Defaults to the function name.
+        """
+
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            _validate_arg_name(arg_name, fn, "db_trigger")
+
+            # Reject async handlers: PollTrigger.run is synchronous and
+            # calling an async function without await would silently return
+            # an unawaited coroutine.
+            if asyncio.iscoroutinefunction(fn):
+                msg = "db_trigger does not support async handlers. Use a sync handler instead."
+                raise ConfigurationError(msg)
+
+            trigger_name = name or fn.__name__
+            trigger = PollTrigger(
+                name=trigger_name,
+                source=source,
+                checkpoint_store=checkpoint_store,
+                normalizer=normalizer,
+                batch_size=batch_size,
+                max_batches_per_tick=max_batches_per_tick,
+                lease_ttl_seconds=lease_ttl_seconds,
+                retry_policy=retry_policy,
+                metrics=metrics,
+            )
+
+            fn_sig = inspect.signature(fn, follow_wrapped=False)
+            has_context = "context" in fn_sig.parameters
+
+            # Identify which params are injected by db decorators vs host
+            # trigger params that must be forwarded to inner wrappers.
+            db_injected = {arg_name}
+            if has_context:
+                db_injected.add("context")
+            host_params = [p_name for p_name in fn_sig.parameters if p_name not in db_injected]
+
+            def invoke_handler(events: Any, context: Any | None = None) -> Any:
+                kwargs: dict[str, Any] = {arg_name: events}
+                if has_context and context is not None:
+                    kwargs["context"] = context
+                return fn(**kwargs)
+
             @functools.wraps(fn)
-            def wrapper(timer: object) -> int:
-                return trigger.run(timer=timer, handler=fn)
+            def wrapper(*args: Any, **kwargs: Any) -> int:
+                # Extract the host trigger argument (e.g. timer) to pass
+                # to PollTrigger.run.  Support both positional and keyword.
+                timer: Any = None
+                if args:
+                    timer = args[0]
+                elif host_params:
+                    timer = kwargs.get(host_params[0])
+                return trigger.run(timer=timer, handler=invoke_handler)
+
+            # Keep host trigger params visible in __signature__ so Azure
+            # worker binding validation can find them.  Only hide the
+            # db-injected params (events, context).
+            wrapper.__signature__ = _build_host_signature(fn, db_injected)  # type: ignore[attr-defined]
 
             return wrapper
 
         return decorator
 
+    def db_input(
+        self,
+        arg_name: str,
+        *,
+        url: str,
+        table: str | None = None,
+        schema: str | None = None,
+        engine_provider: EngineProvider | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Decorator that injects a :class:`DbReader` instance into the handler.
 
-db = _DbNamespace()
+        The handler parameter named ``arg_name`` will receive a pre-configured
+        ``DbReader`` instance.  The reader is created fresh per invocation and
+        closed automatically after the handler returns.
+
+        Supports both sync and async handlers.
+
+        Parameters
+        ----------
+        arg_name:
+            Name of the handler parameter that receives the ``DbReader``.
+        url:
+            SQLAlchemy connection URL.  Supports ``%VAR%`` env-var substitution.
+        table:
+            Optional table name for ``get()`` operations.
+        schema:
+            Optional schema qualifier.
+        engine_provider:
+            Optional shared ``EngineProvider`` for connection pooling.
+        """
+
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            _validate_arg_name(arg_name, fn, "db_input")
+            is_async = asyncio.iscoroutinefunction(fn)
+
+            if is_async:
+
+                @functools.wraps(fn)
+                async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    reader = DbReader(
+                        url=url,
+                        table=table,
+                        schema=schema,
+                        engine_provider=engine_provider,
+                    )
+                    try:
+                        kwargs[arg_name] = reader
+                        return await fn(*args, **kwargs)
+                    finally:
+                        reader.close()
+
+                async_wrapper.__signature__ = _build_host_signature(  # type: ignore[attr-defined]
+                    fn,
+                    {arg_name},
+                )
+                return async_wrapper
+
+            @functools.wraps(fn)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                reader = DbReader(
+                    url=url,
+                    table=table,
+                    schema=schema,
+                    engine_provider=engine_provider,
+                )
+                try:
+                    kwargs[arg_name] = reader
+                    return fn(*args, **kwargs)
+                finally:
+                    reader.close()
+
+            wrapper.__signature__ = _build_host_signature(fn, {arg_name})  # type: ignore[attr-defined]
+            return wrapper
+
+        return decorator
+
+    def db_output(
+        self,
+        arg_name: str,
+        *,
+        url: str,
+        table: str,
+        schema: str | None = None,
+        engine_provider: EngineProvider | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Decorator that injects a :class:`DbWriter` instance into the handler.
+
+        The handler parameter named ``arg_name`` will receive a pre-configured
+        ``DbWriter`` instance.  The writer is created fresh per invocation and
+        closed automatically after the handler returns.
+
+        Supports both sync and async handlers.
+
+        Parameters
+        ----------
+        arg_name:
+            Name of the handler parameter that receives the ``DbWriter``.
+        url:
+            SQLAlchemy connection URL.  Supports ``%VAR%`` env-var substitution.
+        table:
+            Table name for write operations.
+        schema:
+            Optional schema qualifier.
+        engine_provider:
+            Optional shared ``EngineProvider`` for connection pooling.
+        """
+
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            _validate_arg_name(arg_name, fn, "db_output")
+            is_async = asyncio.iscoroutinefunction(fn)
+
+            if is_async:
+
+                @functools.wraps(fn)
+                async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    writer = DbWriter(
+                        url=url,
+                        table=table,
+                        schema=schema,
+                        engine_provider=engine_provider,
+                    )
+                    try:
+                        kwargs[arg_name] = writer
+                        return await fn(*args, **kwargs)
+                    finally:
+                        writer.close()
+
+                async_wrapper.__signature__ = _build_host_signature(  # type: ignore[attr-defined]
+                    fn,
+                    {arg_name},
+                )
+                return async_wrapper
+
+            @functools.wraps(fn)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                writer = DbWriter(
+                    url=url,
+                    table=table,
+                    schema=schema,
+                    engine_provider=engine_provider,
+                )
+                try:
+                    kwargs[arg_name] = writer
+                    return fn(*args, **kwargs)
+                finally:
+                    writer.close()
+
+            wrapper.__signature__ = _build_host_signature(fn, {arg_name})  # type: ignore[attr-defined]
+            return wrapper
+
+        return decorator

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -238,11 +238,8 @@ def test_db_output_injects_writer(tmp_path: Path) -> None:
     engine = create_engine(url)
     try:
         with engine.connect() as conn:
-            rows = (
-                conn.execute(text("SELECT id, status FROM processed_orders ORDER BY id"))
-                .mappings()
-                .all()
-            )
+            result = conn.execute(text("SELECT id, status FROM processed_orders ORDER BY id"))
+            rows = [dict(row._mapping) for row in result]
     finally:
         engine.dispose()
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,167 +1,371 @@
 from __future__ import annotations
 
-import pytest
+from pathlib import Path
 
-from azure_functions_db import NoOpCollector
-from azure_functions_db.decorator import db
+import pytest
+from sqlalchemy import create_engine, text
+
+from azure_functions_db import ConfigurationError, DbFunctionApp, NoOpCollector
+from azure_functions_db.binding.reader import DbReader
+from azure_functions_db.binding.writer import DbWriter
 from azure_functions_db.trigger.errors import FetchError
 from azure_functions_db.trigger.events import RowChange
-from azure_functions_db.trigger.normalizers import default_normalizer
 from tests.test_poll_trigger import FakeSourceAdapter, FakeStateStore
 
 
-def test_db_poll_returns_callable() -> None:
-    decorator = db.poll(
-        name="test_poller",
+def _sqlite_url(tmp_path: Path, name: str) -> str:
+    return f"sqlite:///{tmp_path / name}"
+
+
+def _create_users_table(url: str) -> None:
+    engine = create_engine(url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"))
+            conn.execute(
+                text("INSERT INTO users (id, name) VALUES (:id, :name)"),
+                {"id": 1, "name": "Alice"},
+            )
+    finally:
+        engine.dispose()
+
+
+def _create_orders_table(url: str) -> None:
+    engine = create_engine(url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text("CREATE TABLE processed_orders (id INTEGER PRIMARY KEY, status TEXT NOT NULL)")
+            )
+    finally:
+        engine.dispose()
+
+
+def test_db_trigger_returns_callable() -> None:
+    decorator = DbFunctionApp().db_trigger(
+        arg_name="events",
         source=FakeSourceAdapter(batches=[]),
         checkpoint_store=FakeStateStore(),
     )
-    assert callable(decorator)  # noqa: S101
+
+    assert callable(decorator)
 
 
-def test_decorated_function_accepts_timer() -> None:
-    decorated = db.poll(
-        name="test_poller",
-        source=FakeSourceAdapter(batches=[[{"id": 1, "updated_at": 100}]]),
-        checkpoint_store=FakeStateStore(),
-    )(lambda events: None)
-
-    result = decorated(object())
-    assert result == 1  # noqa: S101
-
-
-def test_decorated_function_calls_handler_with_events() -> None:
+def test_db_trigger_calls_handler_with_events() -> None:
     handled: list[list[RowChange]] = []
 
-    def handler(events: list[RowChange]) -> None:
-        handled.append(events)
-
-    decorated = db.poll(
-        name="test_poller",
+    @DbFunctionApp().db_trigger(
+        arg_name="changes",
         source=FakeSourceAdapter(batches=[[{"id": 1, "updated_at": 100}]]),
         checkpoint_store=FakeStateStore(),
-    )(handler)
+    )
+    def handler(changes: list[RowChange]) -> None:
+        handled.append(changes)
 
-    decorated(object())
+    handler(object())
 
-    assert len(handled) == 1  # noqa: S101
-    assert len(handled[0]) == 1  # noqa: S101
-    assert handled[0][0].pk == {"id": 1}  # noqa: S101
+    assert len(handled) == 1
+    assert len(handled[0]) == 1
+    assert handled[0][0].pk == {"id": 1}
 
 
-def test_decorated_function_returns_processed_count() -> None:
+def test_db_trigger_returns_processed_count() -> None:
+    @DbFunctionApp().db_trigger(
+        arg_name="events",
+        source=FakeSourceAdapter(batches=[[{"id": 1, "updated_at": 100}]]),
+        checkpoint_store=FakeStateStore(),
+    )
     def handler(events: list[RowChange]) -> None:
         del events
 
-    decorated = db.poll(
-        name="test_poller",
-        source=FakeSourceAdapter(batches=[[{"id": 1, "updated_at": 100}]]),
-        checkpoint_store=FakeStateStore(),
-    )(handler)
+    result = handler(object())
 
-    result = decorated(object())
-
-    assert isinstance(result, int)  # noqa: S101
-    assert result == 1  # noqa: S101
+    assert isinstance(result, int)
+    assert result == 1
 
 
-def test_db_poll_async_handler_rejected() -> None:
+def test_db_trigger_async_handler_rejected() -> None:
     async def handler(events: list[RowChange]) -> None:
         del events
 
-    decorated = db.poll(
-        name="test_poller",
-        source=FakeSourceAdapter(batches=[]),
-        checkpoint_store=FakeStateStore(),
-    )(handler)
-
-    with pytest.raises(TypeError, match="Async handlers are not supported"):
-        decorated(object())
+    with pytest.raises(ConfigurationError, match="does not support async"):
+        DbFunctionApp().db_trigger(
+            arg_name="events",
+            source=FakeSourceAdapter(batches=[]),
+            checkpoint_store=FakeStateStore(),
+        )(handler)
 
 
-def test_db_poll_swallows_lease_acquire_error() -> None:
+def test_db_trigger_swallows_lease_error() -> None:
     store = FakeStateStore()
     store.acquire_error = RuntimeError("lease conflict")
 
+    @DbFunctionApp().db_trigger(
+        arg_name="events",
+        source=FakeSourceAdapter(batches=[]),
+        checkpoint_store=store,
+    )
     def handler(events: list[RowChange]) -> None:
         del events
 
-    decorated = db.poll(
-        name="test_poller",
-        source=FakeSourceAdapter(batches=[]),
-        checkpoint_store=store,
-    )(handler)
-
-    result = decorated(object())
-    assert result == 0  # noqa: S101
+    assert handler(object()) == 0
 
 
-def test_db_poll_propagates_other_errors() -> None:
+def test_db_trigger_propagates_other_errors() -> None:
     source = FakeSourceAdapter(batches=[])
     source.fetch_error = RuntimeError("db unavailable")
 
-    def handler(events: list[RowChange]) -> None:
-        del events
-
-    decorated = db.poll(
-        name="test_poller",
+    @DbFunctionApp().db_trigger(
+        arg_name="events",
         source=source,
         checkpoint_store=FakeStateStore(),
-    )(handler)
+    )
+    def handler(events: list[RowChange]) -> None:
+        del events
 
     with pytest.raises(FetchError, match="Failed to fetch"):
-        decorated(object())
+        handler(object())
 
 
-def test_db_poll_accepts_explicit_normalizer() -> None:
-    handled: list[list[RowChange]] = []
-
+def test_db_trigger_preserves_function_name() -> None:
+    @DbFunctionApp().db_trigger(
+        arg_name="events",
+        source=FakeSourceAdapter(batches=[]),
+        checkpoint_store=FakeStateStore(),
+    )
     def handler(events: list[RowChange]) -> None:
-        handled.append(events)
+        del events
 
-    decorated = db.poll(
-        name="test_poller",
+    assert handler.__name__ == "handler"
+
+
+def test_db_trigger_default_name_from_function() -> None:
+    store = FakeStateStore()
+
+    @DbFunctionApp().db_trigger(
+        arg_name="events",
         source=FakeSourceAdapter(batches=[[{"id": 1, "updated_at": 100}]]),
-        checkpoint_store=FakeStateStore(),
-        normalizer=default_normalizer,
-    )(handler)
-
-    decorated(object())
-
-    assert handled[0][0].cursor is None  # noqa: S101
-    assert handled[0][0].pk == {}  # noqa: S101
-
-
-def test_decorator_preserves_function_name() -> None:
-    @db.poll(
-        name="test_poller",
-        source=FakeSourceAdapter(batches=[]),
-        checkpoint_store=FakeStateStore(),
+        checkpoint_store=store,
     )
-    def handler(events: list[RowChange]) -> None:
+    def orders_poll(events: list[RowChange]) -> None:
         del events
 
-    assert handler.__name__ == "handler"  # noqa: S101
+    orders_poll(object())
+
+    assert "orders_poll" in store.checkpoints
 
 
-def test_decorator_preserves_wrapped() -> None:
-    @db.poll(
-        name="test_poller",
-        source=FakeSourceAdapter(batches=[]),
-        checkpoint_store=FakeStateStore(),
+def test_db_trigger_explicit_name() -> None:
+    store = FakeStateStore()
+
+    @DbFunctionApp().db_trigger(
+        arg_name="events",
+        name="custom_poller",
+        source=FakeSourceAdapter(batches=[[{"id": 1, "updated_at": 100}]]),
+        checkpoint_store=store,
     )
-    def handler(events: list[RowChange]) -> None:
+    def orders_poll(events: list[RowChange]) -> None:
         del events
 
-    assert getattr(handler, "__wrapped__", None) is not None  # noqa: S101
+    orders_poll(object())
+
+    assert "custom_poller" in store.checkpoints
 
 
-def test_db_poll_accepts_metrics() -> None:
-    decorated = db.poll(
-        name="test_poller",
+def test_db_trigger_accepts_metrics() -> None:
+    @DbFunctionApp().db_trigger(
+        arg_name="events",
         source=FakeSourceAdapter(batches=[[{"id": 1, "updated_at": 100}]]),
         checkpoint_store=FakeStateStore(),
         metrics=NoOpCollector(),
-    )(lambda events: None)
+    )
+    def handler(events: list[RowChange]) -> None:
+        del events
 
-    assert decorated(object()) == 1  # noqa: S101
+    assert handler(object()) == 1
+
+
+def test_db_input_injects_reader(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "reader.db")
+    _create_users_table(url)
+
+    @DbFunctionApp().db_input("reader", url=url, table="users")
+    def handler(reader: DbReader) -> dict[str, object] | None:
+        return reader.get(pk={"id": 1})
+
+    assert handler() == {"id": 1, "name": "Alice"}
+
+
+def test_db_input_auto_closes_reader(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    url = _sqlite_url(tmp_path, "reader-close.db")
+    _create_users_table(url)
+    closed: list[DbReader] = []
+    original_close = DbReader.close
+
+    def tracking_close(self: DbReader) -> None:
+        closed.append(self)
+        original_close(self)
+
+    monkeypatch.setattr(DbReader, "close", tracking_close)
+
+    @DbFunctionApp().db_input("reader", url=url, table="users")
+    def handler(reader: DbReader) -> None:
+        assert reader.get(pk={"id": 1}) == {"id": 1, "name": "Alice"}
+
+    handler()
+
+    assert len(closed) == 1
+
+
+def test_db_input_invalid_arg_name_raises() -> None:
+    with pytest.raises(ConfigurationError, match="db_input arg_name='reader' not found"):
+
+        @DbFunctionApp().db_input("reader", url="sqlite:///unused.db", table="users")
+        def handler() -> None:
+            return None
+
+
+def test_db_output_injects_writer(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "writer.db")
+    _create_orders_table(url)
+
+    @DbFunctionApp().db_output("writer", url=url, table="processed_orders")
+    def handler(writer: DbWriter) -> None:
+        writer.insert(data={"id": 1, "status": "processed"})
+
+    handler()
+
+    engine = create_engine(url)
+    try:
+        with engine.connect() as conn:
+            rows = (
+                conn.execute(text("SELECT id, status FROM processed_orders ORDER BY id"))
+                .mappings()
+                .all()
+            )
+    finally:
+        engine.dispose()
+
+    assert rows == [{"id": 1, "status": "processed"}]
+
+
+def test_db_output_auto_closes_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    url = _sqlite_url(tmp_path, "writer-close.db")
+    _create_orders_table(url)
+    closed: list[DbWriter] = []
+    original_close = DbWriter.close
+
+    def tracking_close(self: DbWriter) -> None:
+        closed.append(self)
+        original_close(self)
+
+    monkeypatch.setattr(DbWriter, "close", tracking_close)
+
+    @DbFunctionApp().db_output("writer", url=url, table="processed_orders")
+    def handler(writer: DbWriter) -> None:
+        writer.insert(data={"id": 1, "status": "processed"})
+
+    handler()
+
+    assert len(closed) == 1
+
+
+def test_db_output_invalid_arg_name_raises() -> None:
+    with pytest.raises(ConfigurationError, match="db_output arg_name='writer' not found"):
+
+        @DbFunctionApp().db_output("writer", url="sqlite:///unused.db", table="processed")
+        def handler() -> None:
+            return None
+
+
+def test_db_trigger_signature_preserves_host_params() -> None:
+    """Host trigger params (e.g. timer) must stay visible in __signature__."""
+    import inspect
+
+    @DbFunctionApp().db_trigger(
+        arg_name="events",
+        source=FakeSourceAdapter(batches=[]),
+        checkpoint_store=FakeStateStore(),
+    )
+    def handler(timer: object, events: list[RowChange]) -> None:
+        del timer, events
+
+    sig = inspect.signature(handler)
+    assert "timer" in sig.parameters
+    assert "events" not in sig.parameters
+
+
+def test_db_trigger_stacked_with_db_output(tmp_path: Path) -> None:
+    """db_trigger + db_output stacking: events and writer both injected."""
+    url = _sqlite_url(tmp_path, "stack.db")
+    _create_orders_table(url)
+
+    db = DbFunctionApp()
+    captured: dict[str, object] = {}
+
+    @db.db_trigger(
+        arg_name="events",
+        source=FakeSourceAdapter(batches=[[{"id": 1, "updated_at": 100}]]),
+        checkpoint_store=FakeStateStore(),
+    )
+    @db.db_output("writer", url=url, table="processed_orders")
+    def handler(events: list[RowChange], writer: DbWriter) -> None:
+        captured["events_count"] = len(events)
+        captured["has_writer"] = writer is not None
+        writer.insert(data={"id": 1, "status": "done"})
+
+    result = handler(object())
+
+    assert result == 1
+    assert captured["events_count"] == 1
+    assert captured["has_writer"] is True
+
+
+def test_db_trigger_stacked_signature_hides_db_params() -> None:
+    """When stacked, final __signature__ should only show host params."""
+    import inspect
+
+    db = DbFunctionApp()
+
+    @db.db_trigger(
+        arg_name="events",
+        source=FakeSourceAdapter(batches=[]),
+        checkpoint_store=FakeStateStore(),
+    )
+    @db.db_output("writer", url="sqlite:///unused.db", table="t")
+    def handler(timer: object, events: list[RowChange], writer: DbWriter) -> None:
+        del timer, events, writer
+
+    sig = inspect.signature(handler)
+    param_names = list(sig.parameters.keys())
+    assert "timer" in param_names
+    assert "events" not in param_names
+    assert "writer" not in param_names
+
+
+def test_db_trigger_rejects_async_db_output_wrapper() -> None:
+    """db_trigger must reject async-wrapped inner decorators."""
+    db = DbFunctionApp()
+
+    with pytest.raises(ConfigurationError, match="does not support async"):
+
+        @db.db_trigger(
+            arg_name="events",
+            source=FakeSourceAdapter(batches=[]),
+            checkpoint_store=FakeStateStore(),
+        )
+        @db.db_output("writer", url="sqlite:///unused.db", table="t")
+        async def handler(events: list[RowChange], writer: DbWriter) -> None:
+            del events, writer
+
+
+def test_db_trigger_reserved_arg_name_raises() -> None:
+    with pytest.raises(ConfigurationError, match="conflicts with Azure Functions"):
+
+        @DbFunctionApp().db_trigger(
+            arg_name="timer",
+            source=FakeSourceAdapter(batches=[]),
+            checkpoint_store=FakeStateStore(),
+        )
+        def handler(timer: object) -> None:
+            del timer

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -65,7 +65,7 @@ def test_public_api_exports() -> None:
         "StateStoreError",
         "WriteError",
         "build_log_fields",
-        "db",
+        "DbFunctionApp",
         "default_normalizer",
         "make_normalizer",
     }
@@ -79,6 +79,7 @@ def test_imports_resolve() -> None:
         ConfigurationError,
         CursorSerializationError,
         DbConfig,
+        DbFunctionApp,
         DbReader,
         DbWriter,
         EngineProvider,
@@ -95,7 +96,6 @@ def test_imports_resolve() -> None:
         SqlAlchemySource,
         StateStoreError,
         build_log_fields,
-        db,
         default_normalizer,
         make_normalizer,
         parse_checkpoint_cursor,
@@ -107,6 +107,7 @@ def test_imports_resolve() -> None:
     assert ConfigurationError is not None
     assert CursorSerializationError is not None
     assert DbConfig is not None
+    assert DbFunctionApp is not None
     assert DbReader is not None
     assert DbWriter is not None
     assert EngineProvider is not None
@@ -124,7 +125,6 @@ def test_imports_resolve() -> None:
     assert SqlAlchemySource is not None
     assert StateStoreError is not None
     assert build_log_fields is not None
-    assert db is not None
     assert default_normalizer is not None
     assert make_normalizer is not None
     assert parse_checkpoint_cursor is not None


### PR DESCRIPTION
## Summary

Redesign the decorator API from `_DbNamespace.poll()` to an Azure Functions-native `DbFunctionApp` class with three decorator methods:

- **`db_trigger`** — wraps PollTrigger with `__signature__` management to keep host trigger params visible while hiding injected db params
- **`db_input`** — injects DbReader per invocation with automatic lifecycle management (create/close)
- **`db_output`** — injects DbWriter per invocation with automatic lifecycle management (create/close)

## Key Design Decisions

- **`__signature__` management**: Host trigger params (e.g. `timer`) remain visible to Azure worker binding validation; only db-injected params (`events`, `writer`, `reader`) are hidden
- **Async rejection at decoration time**: `db_trigger` rejects async handlers (including async-wrapped `db_input`/`db_output`) to prevent unawaited coroutines since `PollTrigger.run` is synchronous
- **Reserved arg validation**: `_RESERVED_ARGS` prevents collision with Azure Functions runtime param names
- **Decorator stacking**: Supports `@db.db_trigger` + `@db.db_output`/`@db.db_input` composition

## Oracle Review

Pre-design consultation identified Direction A (DbFunctionApp, not subclassing FunctionApp). Post-implementation review found 2 CRITICAL issues, both fixed:

1. ~~`db_trigger` hid all host trigger params from `__signature__`~~ → Now preserves host params
2. ~~Async-wrapped inner decorators slipped through~~ → Now rejected at decoration time

## Changes

### Code (4 files)
- `src/azure_functions_db/decorator.py` — Complete rewrite: `DbFunctionApp` class
- `src/azure_functions_db/__init__.py` — Export `DbFunctionApp` instead of `db`
- `tests/test_decorator.py` — 22 test cases (trigger, input, output, stacking, signature, async)
- `tests/test_public_api.py` — Updated exports

### Documentation (8 files)
- `docs/04-python-api-spec.md` — New decorator API section, updated examples
- `docs/02-architecture.md` — Added decorator layer
- `docs/08-repo-structure.md` — Updated module descriptions
- `docs/14-roadmap.md` — Marked decorator sugar as done
- `docs/21-dev-checklist.md` — Marked binding decorator sugar as done
- `docs/22-binding-semantics.md` — Updated decorator API section
- `docs/23-ADR-005-unified-package-design.md` — Updated API strategy
- `docs/index.md` — Added DbFunctionApp to imports

### Examples & README (5 files)
- All examples updated to use `DbFunctionApp` with `timer` in handler signatures
- README updated with all 3 decorator patterns + combined example

## Breaking Changes

- `db` singleton removed → use `DbFunctionApp()` instance
- `@db.poll(...)` → `@db.db_trigger(arg_name=..., ...)`
- Handler must declare host trigger param (e.g. `timer`) in signature

No backward compatibility needed — no users yet (big-bang change).