### PR TITLE
feat(decorator): redesign db_input/db_output to data injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Azure Functions Python v2 has no built-in database integration story:
 - **Pseudo DB trigger** — poll-based change detection with checkpoint, lease, and at-least-once delivery
 - **Multi-DB support** — PostgreSQL, MySQL, and SQL Server via SQLAlchemy dialects
 - **Single `pip install`** — one package with optional extras for each database driver
-- **DbReader** — input binding for reading rows
-- **DbWriter** — output binding for writing rows (insert, upsert, update, delete)
+- **Data injection** — `db_input` injects query results directly; `db_output` auto-writes return values
+- **Client injection** — `db_reader`/`db_writer` for imperative control when needed
 
 ## Shared Core
 
@@ -97,53 +97,82 @@ def orders_poll(timer: func.TimerRequest, events: list[RowChange]) -> None:
 
 > See [Python API Spec](docs/04-python-api-spec.md) for the full API reference.
 
-### Input Binding (DbReader)
+### Input Binding (data injection)
+
+`db_input` injects the actual query result into your handler — no client needed.
 
 ```python
-from azure_functions_db import DbFunctionApp, DbReader
+from azure_functions_db import DbFunctionApp
 
 db = DbFunctionApp()
 
-@db.db_input("reader", url="%DB_URL%", table="users")
-def load_user(reader: DbReader) -> None:
-    user = reader.get(pk={"id": 42})
+# Single row by primary key (static)
+@db.db_input("user", url="%DB_URL%", table="users", pk={"id": 42})
+def load_user(user: dict | None) -> None:
     if user:
         print(user["name"])
 
-@db.db_input("reader", url="%DB_URL%")
-def list_active_users(reader: DbReader) -> None:
-    active_users = reader.query(
-        "SELECT * FROM users WHERE active = :active",
-        params={"active": True},
-    )
-    for user in active_users:
+# Single row by primary key (dynamic — resolved from handler kwargs)
+@db.db_input("user", url="%DB_URL%", table="users",
+             pk=lambda req: {"id": req.params["id"]})
+def get_user(req, user: dict | None) -> None:
+    print(user)
+
+# Multiple rows by SQL query
+@db.db_input("users", url="%DB_URL%",
+             query="SELECT * FROM users WHERE active = :active",
+             params={"active": True})
+def list_active_users(users: list[dict]) -> None:
+    for user in users:
         print(user["email"])
 ```
 
-### Output Binding (DbWriter)
+### Output Binding (auto-write)
+
+`db_output` writes the handler's return value to the database automatically.
 
 ```python
-from azure_functions_db import DbFunctionApp, DbWriter
+from azure_functions_db import DbFunctionApp
 
 db = DbFunctionApp()
 
-@db.db_output("writer", url="%DB_URL%", table="orders")
-def write_orders(writer: DbWriter) -> None:
-    writer.insert(data={"id": 1, "status": "pending", "total": 99.99})
-    writer.upsert(
-        data={"id": 1, "status": "shipped", "total": 99.99},
-        conflict_columns=["id"],
-    )
+# Insert — return a dict for single row, list[dict] for batch
+@db.db_output(url="%DB_URL%", table="orders")
+def create_order() -> dict:
+    return {"id": 1, "status": "pending", "total": 99.99}
 
-@db.db_output("writer", url="%DB_URL%", table="orders")
-def write_order_batch(writer: DbWriter) -> None:
-    writer.insert_many(rows=[
+# Upsert — set action and conflict_columns
+@db.db_output(url="%DB_URL%", table="orders",
+              action="upsert", conflict_columns=["id"])
+def upsert_orders() -> list[dict]:
+    return [
+        {"id": 1, "status": "shipped", "total": 99.99},
         {"id": 2, "status": "pending", "total": 49.99},
-        {"id": 3, "status": "pending", "total": 29.99},
-    ])
+    ]
 ```
 
 Supported upsert dialects: PostgreSQL, SQLite, MySQL.
+
+### Client Injection (imperative escape hatches)
+
+For complex operations (multiple queries, transactions, update/delete), use `db_reader`/`db_writer` to get a client instance:
+
+```python
+from azure_functions_db import DbFunctionApp, DbReader, DbWriter
+
+db = DbFunctionApp()
+
+@db.db_reader("reader", url="%DB_URL%", table="users")
+def complex_read(reader: DbReader) -> None:
+    user = reader.get(pk={"id": 42})
+    orders = reader.query("SELECT * FROM orders WHERE user_id = :uid", params={"uid": 42})
+
+@db.db_writer("writer", url="%DB_URL%", table="orders")
+def complex_write(writer: DbWriter) -> None:
+    writer.insert(data={"id": 1, "status": "pending"})
+    writer.update(data={"status": "shipped"}, pk={"id": 1})
+    writer.delete(pk={"id": 1})
+```
 
 ### Combined: Trigger + Binding
 
@@ -156,7 +185,6 @@ from azure.storage.blob import ContainerClient
 from azure_functions_db import (
     BlobCheckpointStore,
     DbFunctionApp,
-    DbWriter,
     EngineProvider,
     RowChange,
     SqlAlchemySource,
@@ -187,22 +215,22 @@ checkpoint_store = BlobCheckpointStore(
 @app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
 @db.db_trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
 @db.db_output(
-    arg_name="writer",
     url="%DEST_DB_URL%",
     table="processed_orders",
+    action="upsert",
+    conflict_columns=["order_id"],
     engine_provider=engine_provider,
 )
-def orders_poll(timer: func.TimerRequest, events: list[RowChange], writer: DbWriter) -> None:
-    for event in events:
-        if event.after is not None:
-            writer.upsert(
-                data={
-                    "order_id": event.pk["id"],
-                    "customer": event.after["name"],
-                    "processed_at": str(event.cursor),
-                },
-                conflict_columns=["order_id"],
-            )
+def orders_poll(timer: func.TimerRequest, events: list[RowChange]) -> list[dict]:
+    return [
+        {
+            "order_id": event.pk["id"],
+            "customer": event.after["name"],
+            "processed_at": str(event.cursor),
+        }
+        for event in events
+        if event.after is not None
+    ]
 ```
 
 See [`examples/trigger_with_binding/`](examples/trigger_with_binding/) for a complete runnable sample.

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -19,7 +19,8 @@
     - per-invocation session/connection lifecycle management
 4. **decorator**
     - `DbFunctionApp` class providing Azure Functions-style decorators
-    - `db_trigger` wraps `PollTrigger`, `db_input` injects `DbReader`, `db_output` injects `DbWriter`
+    - `db_trigger` wraps `PollTrigger`, `db_input` injects query results, `db_output` auto-writes return values
+    - `db_reader` / `db_writer` provide imperative `DbReader` / `DbWriter` injection
     - consumes both `trigger` and `binding` modules
 
 ### 1.1 Core Layer

--- a/docs/04-python-api-spec.md
+++ b/docs/04-python-api-spec.md
@@ -77,7 +77,14 @@ def orders_poll(timer: func.TimerRequest, events: list[RowChange]) -> None:
         print(event.pk, event.after)
 ```
 
-The `DbFunctionApp` class provides Azure Functions-style decorators (`db_trigger`, `db_input`, `db_output`). Internally, `db_trigger` wraps `PollTrigger` and manages `__signature__` to hide injected parameters from the Azure runtime. Decorator order contract: Azure decorators outermost, db decorators closest to the function.
+The `DbFunctionApp` class provides Azure Functions-style decorators:
+
+- **`db_trigger`** — pseudo-trigger wrapping `PollTrigger` for change detection
+- **`db_input`** — data injection (injects query results directly)
+- **`db_output`** — auto-write (writes handler return value to DB)
+- **`db_reader`** / **`db_writer`** — client injection (imperative escape hatches)
+
+Internally, decorators manage `__signature__` to hide injected parameters from the Azure runtime. Decorator order contract: Azure decorators outermost, db decorators closest to the function.
 
 ## 3. Core Types
 
@@ -227,7 +234,7 @@ class SerializationError(PollerError): ...
 - BlobCheckpointStore
 - RowChange
 - PollContext
-- DbFunctionApp (db_trigger, db_input, db_output)
+- DbFunctionApp (db_trigger, db_input, db_output, db_reader, db_writer)
 - DbReader
 - DbWriter
 
@@ -257,7 +264,7 @@ writer.upsert_many(rows=[...], conflict_columns=["id"])
 
 ### 10.3 Combined Trigger + Binding Example
 
-Using the decorator API with `DbFunctionApp`:
+Using the decorator API with `DbFunctionApp` (data injection):
 
 ```python
 import azure.functions as func
@@ -266,7 +273,6 @@ from azure.storage.blob import ContainerClient
 from azure_functions_db import (
     BlobCheckpointStore,
     DbFunctionApp,
-    DbWriter,
     EngineProvider,
     RowChange,
     SqlAlchemySource,
@@ -298,22 +304,22 @@ checkpoint_store = BlobCheckpointStore(
 @app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
 @db.db_trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
 @db.db_output(
-    arg_name="writer",
     url="%DEST_DB_URL%",
     table="processed_orders",
+    action="upsert",
+    conflict_columns=["order_id"],
     engine_provider=engine_provider,
 )
-def orders_poll(timer: func.TimerRequest, events: list[RowChange], writer: DbWriter) -> None:
-    for event in events:
-        if event.after is not None:
-            writer.upsert(
-                data={
-                    "order_id": event.pk["id"],
-                    "customer": event.after["name"],
-                    "processed_at": str(event.cursor),
-                },
-                conflict_columns=["order_id"],
-            )
+def orders_poll(timer: func.TimerRequest, events: list[RowChange]) -> list[dict]:
+    return [
+        {
+            "order_id": event.pk["id"],
+            "customer": event.after["name"],
+            "processed_at": str(event.cursor),
+        }
+        for event in events
+        if event.after is not None
+    ]
 ```
 
 Using the imperative API directly:
@@ -403,40 +409,103 @@ class WriteError(DbError): ...
 
 ### 10.7 Decorator API for Bindings (DbFunctionApp)
 
-The `DbFunctionApp` class provides `db_input` and `db_output` decorators that inject
-`DbReader` / `DbWriter` instances per invocation with automatic lifecycle management.
+The `DbFunctionApp` class provides two styles of binding decorators:
 
-#### db_input (inject DbReader)
+#### db_input (data injection)
+
+Injects actual query results into the handler parameter. Exactly one of `pk` or `query` must be provided.
 
 ```python
-from azure_functions_db import DbFunctionApp, DbReader
+from azure_functions_db import DbFunctionApp
 
 db = DbFunctionApp()
 
-@db.db_input("reader", url="%DB_URL%", table="users")
-def load_user(reader: DbReader) -> dict[str, object] | None:
-    return reader.get(pk={"id": 42})
+# Single row by primary key (static)
+@db.db_input("user", url="%DB_URL%", table="users", pk={"id": 42})
+def load_user(user: dict | None) -> None:
+    if user:
+        print(user["name"])
 
-@db.db_input("reader", url="%DB_URL%")
-def list_active(reader: DbReader) -> list[dict[str, object]]:
-    return reader.query("SELECT * FROM users WHERE active = :active", params={"active": True})
+# Single row by primary key (dynamic — resolved from handler kwargs)
+@db.db_input("user", url="%DB_URL%", table="users",
+             pk=lambda req: {"id": req.params["id"]})
+def get_user(req, user: dict | None) -> None:
+    print(user)
+
+# Multiple rows by SQL query
+@db.db_input("users", url="%DB_URL%",
+             query="SELECT * FROM users WHERE active = :active",
+             params={"active": True})
+def list_active(users: list[dict]) -> None:
+    for user in users:
+        print(user["email"])
+
+# Dynamic query params
+@db.db_input("users", url="%DB_URL%",
+             query="SELECT * FROM users WHERE org_id = :org_id",
+             params=lambda req: {"org_id": req.params["org_id"]})
+def list_org_users(req, users: list[dict]) -> None:
+    print(users)
 ```
 
-#### db_output (inject DbWriter)
+Parameters:
+- `pk`: `dict | Callable` — static or dynamic primary key (requires `table`)
+- `query`: `str` — SQL query with `:name` placeholders
+- `params`: `dict | Callable` — query parameters (only with `query`)
+- `on_not_found`: `"none"` (default) or `"raise"` — behavior when pk lookup returns no row
+
+#### db_output (auto-write)
+
+Writes the handler's return value to the database automatically.
 
 ```python
-from azure_functions_db import DbFunctionApp, DbWriter
+from azure_functions_db import DbFunctionApp
 
 db = DbFunctionApp()
 
-@db.db_output("writer", url="%DB_URL%", table="orders")
-def write_order(writer: DbWriter) -> None:
-    writer.insert(data={"id": 1, "status": "pending", "total": 99.99})
-    writer.upsert(data={"id": 1, "status": "shipped"}, conflict_columns=["id"])
+# Insert (default) — dict for single row, list[dict] for batch
+@db.db_output(url="%DB_URL%", table="orders")
+def create_order() -> dict:
+    return {"id": 1, "status": "pending", "total": 99.99}
+
+# Upsert — requires conflict_columns
+@db.db_output(url="%DB_URL%", table="orders",
+              action="upsert", conflict_columns=["id"])
+def upsert_order() -> dict:
+    return {"id": 1, "status": "shipped", "total": 99.99}
 ```
 
-Both decorators support sync and async handlers.  The injected instance is created
-fresh per invocation and closed automatically in a `finally` block.
+Return value contract:
+- `dict` → single-row write
+- `list[dict]` → batch write
+- `None` → no-op
+
+Parameters:
+- `action`: `"insert"` (default) or `"upsert"`
+- `conflict_columns`: required when `action="upsert"`
+
+#### db_reader / db_writer (client injection)
+
+Imperative escape hatches for complex operations. Inject `DbReader` / `DbWriter` instances.
+
+```python
+from azure_functions_db import DbFunctionApp, DbReader, DbWriter
+
+db = DbFunctionApp()
+
+@db.db_reader("reader", url="%DB_URL%", table="users")
+def complex_read(reader: DbReader) -> None:
+    user = reader.get(pk={"id": 42})
+    orders = reader.query("SELECT * FROM orders WHERE user_id = :uid", params={"uid": 42})
+
+@db.db_writer("writer", url="%DB_URL%", table="orders")
+def complex_write(writer: DbWriter) -> None:
+    writer.insert(data={"id": 1, "status": "pending"})
+    writer.update(data={"status": "shipped"}, pk={"id": 1})
+```
+
+All decorators support sync and async handlers.  Instances are created fresh per
+invocation and closed automatically in a `finally` block.
 
 ## 11. Shared Core API
 

--- a/docs/22-binding-semantics.md
+++ b/docs/22-binding-semantics.md
@@ -97,10 +97,28 @@ Unlike triggers, they do not manage state (checkpoint/lease) and operate on a pe
 
 ## 7. Future Extensions
 
-### 7.1 Decorator API (DbFunctionApp)
-- `@db.db_input()` and `@db.db_output()` — decorators that inject `DbReader` / `DbWriter` per invocation
+## 7. Decorator API (DbFunctionApp)
+
+### 7.1 Data Injection Decorators
+
+- `@db.db_input()` — injects query results directly into handler parameter
+  - PK mode: `pk=dict | Callable` → injects `dict | None`
+  - Query mode: `query=str, params=dict | Callable` → injects `list[dict]`
+  - `on_not_found="none"` (default) or `"raise"` for strict mode
+- `@db.db_output()` — auto-writes handler return value to DB
+  - `action="insert"` (default) or `"upsert"` with `conflict_columns`
+  - Return `dict` for single row, `list[dict]` for batch, `None` for no-op
+
+### 7.2 Client Injection Decorators (imperative escape hatches)
+
+- `@db.db_reader()` — injects `DbReader` instance per invocation
+- `@db.db_writer()` — injects `DbWriter` instance per invocation
+- Use for complex operations: multiple queries, transactions, update/delete
+
+### 7.3 Trigger Decorator
+
 - `@db.db_trigger()` — decorator that wraps `PollTrigger` for change detection
-- Implemented via `DbFunctionApp` class with automatic lifecycle management (create/close per invocation)
+- Implemented via `DbFunctionApp` class with automatic lifecycle management
 - See [Python API Spec](04-python-api-spec.md) for full usage
 
 ### 7.2 DbSession (if needed)

--- a/examples/trigger_with_binding/function_app.py
+++ b/examples/trigger_with_binding/function_app.py
@@ -1,8 +1,11 @@
 """Trigger + Binding integration example.
 
 Demonstrates using DbFunctionApp decorators to detect DB changes and write
-processed results to a destination table. Uses EngineProvider for shared
-connection pooling across trigger and bindings.
+processed results to a destination table.
+
+Shows two patterns:
+    1. ``db_output`` — return-value auto-write (declarative)
+    2. ``db_writer`` — client injection (imperative, for complex operations)
 
 Requirements:
     pip install azure-functions-db[postgres]
@@ -55,12 +58,38 @@ checkpoint_store = BlobCheckpointStore(
 @app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
 @db.db_trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
 @db.db_output(
-    arg_name="writer",
+    url="%DEST_DB_URL%",
+    table="processed_orders",
+    action="upsert",
+    conflict_columns=["order_id"],
+    engine_provider=engine_provider,
+)
+def orders_poll(timer: func.TimerRequest, events: list[RowChange]) -> list[dict[str, object]]:
+    del timer
+    return [
+        {
+            "order_id": event.pk["id"],
+            "customer_name": event.after["name"],
+            "amount": event.after["amount"],
+            "processed_at": str(event.cursor),
+        }
+        for event in events
+        if event.after is not None
+    ]
+
+
+@app.function_name(name="orders_poll_imperative")
+@app.schedule(schedule="0 */5 * * * *", arg_name="timer", use_monitor=True)
+@db.db_trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+@db.db_writer(
+    "writer",
     url="%DEST_DB_URL%",
     table="processed_orders",
     engine_provider=engine_provider,
 )
-def orders_poll(timer: func.TimerRequest, events: list[RowChange], writer: DbWriter) -> None:
+def orders_poll_imperative(
+    timer: func.TimerRequest, events: list[RowChange], writer: DbWriter
+) -> None:
     del timer
     for event in events:
         if event.after is not None:

--- a/src/azure_functions_db/decorator.py
+++ b/src/azure_functions_db/decorator.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 import functools
 import inspect
 import logging
-from typing import Any
+from typing import Any, Literal
 
 from .binding.reader import DbReader
 from .binding.writer import DbWriter
@@ -51,12 +51,67 @@ def _build_host_signature(
     return sig.replace(parameters=params)
 
 
+def _validate_resolver(
+    resolver: Callable[..., dict[str, object]],
+    fn: Callable[..., Any],
+    injected_args: set[str],
+    param_label: str,
+    decorator_name: str,
+) -> list[str]:
+    """Validate a resolver callable at decoration time.
+
+    Ensures the resolver's parameter names are a subset of the handler's
+    non-injected parameters and that it does not use ``*args`` or ``**kwargs``.
+
+    Returns the list of parameter names the resolver expects.
+    """
+    resolver_sig = inspect.signature(resolver)
+    for p in resolver_sig.parameters.values():
+        if p.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            msg = f"{decorator_name} {param_label} callable must not use *args or **kwargs"
+            raise ConfigurationError(msg)
+
+    handler_sig = inspect.signature(fn, follow_wrapped=False)
+    handler_params = {name for name in handler_sig.parameters if name not in injected_args}
+    resolver_params = list(resolver_sig.parameters.keys())
+    unknown = set(resolver_params) - handler_params
+    if unknown:
+        msg = (
+            f"{decorator_name} {param_label} callable references parameters "
+            f"{sorted(unknown)} not found in handler '{fn.__name__}'. "
+            f"Available: {sorted(handler_params)}"
+        )
+        raise ConfigurationError(msg)
+    return resolver_params
+
+
+def _resolve_callable(
+    resolver: Callable[..., dict[str, object]],
+    resolver_params: list[str],
+    all_kwargs: dict[str, Any],
+) -> dict[str, object]:
+    """Call a resolver with matching kwargs extracted from the handler invocation."""
+    call_kwargs = {name: all_kwargs[name] for name in resolver_params if name in all_kwargs}
+    return resolver(**call_kwargs)
+
+
 class DbFunctionApp:
     """Azure Functions-style decorator API for database integration.
 
-    Provides ``db_trigger``, ``db_input``, and ``db_output`` decorator
-    methods that wrap the imperative API (PollTrigger, DbReader, DbWriter)
-    in an Azure Functions-native decorator experience.
+    Provides ``db_trigger``, ``db_input``, ``db_output``, ``db_reader``,
+    and ``db_writer`` decorator methods that wrap the imperative API
+    (PollTrigger, DbReader, DbWriter) in an Azure Functions-native
+    decorator experience.
+
+    **Data injection** (``db_input`` / ``db_output``):
+        Handlers receive actual data or have return values auto-written.
+
+    **Client injection** (``db_reader`` / ``db_writer``):
+        Handlers receive ``DbReader`` / ``DbWriter`` instances for
+        imperative control.
 
     Decorator order contract:
         Azure decorators outermost, db decorators closest to the function::
@@ -168,7 +223,276 @@ class DbFunctionApp:
 
         return decorator
 
+    # ------------------------------------------------------------------
+    # Data injection decorators
+    # ------------------------------------------------------------------
+
     def db_input(
+        self,
+        arg_name: str,
+        *,
+        url: str,
+        table: str | None = None,
+        schema: str | None = None,
+        pk: dict[str, object] | Callable[..., dict[str, object]] | None = None,
+        query: str | None = None,
+        params: dict[str, object] | Callable[..., dict[str, object]] | None = None,
+        on_not_found: Literal["none", "raise"] = "none",
+        engine_provider: EngineProvider | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Decorator that injects query results into the handler.
+
+        The handler parameter named ``arg_name`` will receive the actual
+        data from the database, not a ``DbReader`` instance.  Exactly one
+        of ``pk`` or ``query`` must be provided.
+
+        **PK mode** (single row):
+            The parameter receives ``dict[str, object] | None``.  Use a
+            static dict for fixed lookups or a callable for dynamic
+            resolution from other handler parameters::
+
+                @db.db_input("user", url=..., table="users",
+                             pk=lambda req: {"id": req.params["id"]})
+                def handler(req, user): ...
+
+        **Query mode** (multiple rows):
+            The parameter receives ``list[dict[str, object]]``::
+
+                @db.db_input("users", url=...,
+                             query="SELECT * FROM users WHERE active = :active",
+                             params={"active": True})
+                def handler(users): ...
+
+        Parameters
+        ----------
+        arg_name:
+            Name of the handler parameter that receives the data.
+        url:
+            SQLAlchemy connection URL.  Supports ``%VAR%`` env-var substitution.
+        table:
+            Table name.  Required when using ``pk``.
+        schema:
+            Optional schema qualifier.
+        pk:
+            Primary key for single-row lookup.  Either a static dict or a
+            callable whose parameter names match other handler parameters.
+        query:
+            SQL query string for multi-row results.  Use ``:name``
+            placeholders for parameters.
+        params:
+            Parameters for ``query``.  Either a static dict or a callable.
+        on_not_found:
+            Behavior when ``pk`` lookup returns no row.  ``"none"`` (default)
+            injects ``None``; ``"raise"`` raises ``NotFoundError``.
+        engine_provider:
+            Optional shared ``EngineProvider`` for connection pooling.
+        """
+        # Validate mutual exclusion at call time (before decoration).
+        if pk is not None and query is not None:
+            msg = "db_input requires exactly one of 'pk' or 'query', not both"
+            raise ConfigurationError(msg)
+        if pk is None and query is None:
+            msg = "db_input requires exactly one of 'pk' or 'query'"
+            raise ConfigurationError(msg)
+        if pk is not None and table is None:
+            msg = "db_input with 'pk' requires 'table' to be set"
+            raise ConfigurationError(msg)
+        if params is not None and query is None:
+            msg = "db_input 'params' is only valid with 'query'"
+            raise ConfigurationError(msg)
+
+        use_pk = pk is not None
+        pk_callable: Callable[..., dict[str, object]] | None = pk if callable(pk) else None
+        pk_static: dict[str, object] | None = None if callable(pk) else pk
+        params_callable: Callable[..., dict[str, object]] | None = (
+            params if callable(params) else None
+        )
+        params_static: dict[str, object] | None = None if callable(params) else params
+
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            _validate_arg_name(arg_name, fn, "db_input")
+
+            pk_resolver_params: list[str] = []
+            params_resolver_params: list[str] = []
+            if pk_callable is not None:
+                pk_resolver_params = _validate_resolver(
+                    pk_callable, fn, {arg_name}, "pk", "db_input"
+                )
+            if params_callable is not None:
+                params_resolver_params = _validate_resolver(
+                    params_callable, fn, {arg_name}, "params", "db_input"
+                )
+
+            is_async = asyncio.iscoroutinefunction(fn)
+
+            def _do_read(all_kwargs: dict[str, Any]) -> Any:
+                """Execute the DB read (runs in calling thread)."""
+                reader = DbReader(
+                    url=url,
+                    table=table,
+                    schema=schema,
+                    engine_provider=engine_provider,
+                )
+                try:
+                    if use_pk:
+                        resolved_pk: dict[str, object]
+                        if pk_callable is not None:
+                            resolved_pk = _resolve_callable(
+                                pk_callable, pk_resolver_params, all_kwargs
+                            )
+                        else:
+                            assert pk_static is not None
+                            resolved_pk = pk_static
+                        result = reader.get(pk=resolved_pk)
+                        if result is None and on_not_found == "raise":
+                            from .core.errors import NotFoundError
+
+                            msg = f"db_input: no row found for pk={resolved_pk} in table '{table}'"
+                            raise NotFoundError(msg)
+                        return result
+                    else:
+                        resolved_params: dict[str, object] | None = None
+                        if params_callable is not None:
+                            resolved_params = _resolve_callable(
+                                params_callable, params_resolver_params, all_kwargs
+                            )
+                        elif params_static is not None:
+                            resolved_params = params_static
+                        assert query is not None
+                        return reader.query(query, params=resolved_params)
+                finally:
+                    reader.close()
+
+            if is_async:
+
+                @functools.wraps(fn)
+                async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    data = await asyncio.to_thread(_do_read, kwargs)
+                    kwargs[arg_name] = data
+                    return await fn(*args, **kwargs)
+
+                async_wrapper.__signature__ = _build_host_signature(  # type: ignore[attr-defined]
+                    fn,
+                    {arg_name},
+                )
+                return async_wrapper
+
+            @functools.wraps(fn)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                data = _do_read(kwargs)
+                kwargs[arg_name] = data
+                return fn(*args, **kwargs)
+
+            wrapper.__signature__ = _build_host_signature(fn, {arg_name})  # type: ignore[attr-defined]
+            return wrapper
+
+        return decorator
+
+    def db_output(
+        self,
+        *,
+        url: str,
+        table: str,
+        schema: str | None = None,
+        action: Literal["insert", "upsert"] = "insert",
+        conflict_columns: list[str] | None = None,
+        engine_provider: EngineProvider | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Decorator that auto-writes the handler's return value to the database.
+
+        The handler's return value is intercepted and written to the
+        configured table.  No ``arg_name`` is needed.
+
+        Return value contract:
+            - ``dict`` -> single-row write
+            - ``list[dict]`` -> batch write
+            - ``None`` -> no-op
+
+        Parameters
+        ----------
+        url:
+            SQLAlchemy connection URL.  Supports ``%VAR%`` env-var substitution.
+        table:
+            Table name for write operations.
+        schema:
+            Optional schema qualifier.
+        action:
+            Write action: ``"insert"`` (default) or ``"upsert"``.
+        conflict_columns:
+            Columns for upsert conflict resolution.  Required when
+            ``action="upsert"``.
+        engine_provider:
+            Optional shared ``EngineProvider`` for connection pooling.
+        """
+        if action == "upsert" and not conflict_columns:
+            msg = "db_output with action='upsert' requires 'conflict_columns'"
+            raise ConfigurationError(msg)
+
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            is_async = asyncio.iscoroutinefunction(fn)
+
+            def _do_write(result: Any) -> None:
+                """Write the handler result to DB (runs in calling thread)."""
+                if result is None:
+                    return
+
+                writer = DbWriter(
+                    url=url,
+                    table=table,
+                    schema=schema,
+                    engine_provider=engine_provider,
+                )
+                try:
+                    if isinstance(result, dict):
+                        if action == "upsert":
+                            assert conflict_columns is not None
+                            writer.upsert(data=result, conflict_columns=conflict_columns)
+                        else:
+                            writer.insert(data=result)
+                    elif isinstance(result, list):
+                        if action == "upsert":
+                            assert conflict_columns is not None
+                            writer.upsert_many(rows=result, conflict_columns=conflict_columns)
+                        else:
+                            writer.insert_many(rows=result)
+                    else:
+                        msg = (
+                            f"db_output: handler returned {type(result).__name__}, "
+                            f"expected dict, list[dict], or None"
+                        )
+                        raise ConfigurationError(msg)
+                finally:
+                    writer.close()
+
+            fn_sig = inspect.signature(fn, follow_wrapped=False)
+
+            if is_async:
+
+                @functools.wraps(fn)
+                async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    result = await fn(*args, **kwargs)
+                    await asyncio.to_thread(_do_write, result)
+                    return result
+
+                async_wrapper.__signature__ = fn_sig  # type: ignore[attr-defined]
+                return async_wrapper
+
+            @functools.wraps(fn)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                result = fn(*args, **kwargs)
+                _do_write(result)
+                return result
+
+            wrapper.__signature__ = fn_sig  # type: ignore[attr-defined]
+            return wrapper
+
+        return decorator
+
+    # ------------------------------------------------------------------
+    # Client injection decorators (imperative escape hatches)
+    # ------------------------------------------------------------------
+
+    def db_reader(
         self,
         arg_name: str,
         *,
@@ -178,6 +502,10 @@ class DbFunctionApp:
         engine_provider: EngineProvider | None = None,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorator that injects a :class:`DbReader` instance into the handler.
+
+        Use this when you need imperative control over reads (multiple
+        queries, dynamic SQL, etc.).  For simple data injection, prefer
+        :meth:`db_input`.
 
         The handler parameter named ``arg_name`` will receive a pre-configured
         ``DbReader`` instance.  The reader is created fresh per invocation and
@@ -200,7 +528,7 @@ class DbFunctionApp:
         """
 
         def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
-            _validate_arg_name(arg_name, fn, "db_input")
+            _validate_arg_name(arg_name, fn, "db_reader")
             is_async = asyncio.iscoroutinefunction(fn)
 
             if is_async:
@@ -244,7 +572,7 @@ class DbFunctionApp:
 
         return decorator
 
-    def db_output(
+    def db_writer(
         self,
         arg_name: str,
         *,
@@ -254,6 +582,10 @@ class DbFunctionApp:
         engine_provider: EngineProvider | None = None,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorator that injects a :class:`DbWriter` instance into the handler.
+
+        Use this when you need imperative control over writes (multiple
+        operations, transactions, update/delete, etc.).  For simple
+        auto-write, prefer :meth:`db_output`.
 
         The handler parameter named ``arg_name`` will receive a pre-configured
         ``DbWriter`` instance.  The writer is created fresh per invocation and
@@ -276,7 +608,7 @@ class DbFunctionApp:
         """
 
         def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
-            _validate_arg_name(arg_name, fn, "db_output")
+            _validate_arg_name(arg_name, fn, "db_writer")
             is_async = asyncio.iscoroutinefunction(fn)
 
             if is_async:

--- a/src/azure_functions_db/decorator.py
+++ b/src/azure_functions_db/decorator.py
@@ -73,6 +73,12 @@ def _validate_resolver(
         ):
             msg = f"{decorator_name} {param_label} callable must not use *args or **kwargs"
             raise ConfigurationError(msg)
+        if p.kind == inspect.Parameter.POSITIONAL_ONLY:
+            msg = (
+                f"{decorator_name} {param_label} callable must not use positional-only "
+                f"parameters ('{p.name}'). Use keyword-compatible parameters instead."
+            )
+            raise ConfigurationError(msg)
 
     handler_sig = inspect.signature(fn, follow_wrapped=False)
     handler_params = {name for name in handler_sig.parameters if name not in injected_args}
@@ -190,28 +196,32 @@ class DbFunctionApp:
             fn_sig = inspect.signature(fn, follow_wrapped=False)
             has_context = "context" in fn_sig.parameters
 
-            # Identify which params are injected by db decorators vs host
-            # trigger params that must be forwarded to inner wrappers.
             db_injected = {arg_name}
             if has_context:
                 db_injected.add("context")
             host_params = [p_name for p_name in fn_sig.parameters if p_name not in db_injected]
 
-            def invoke_handler(events: Any, context: Any | None = None) -> Any:
-                kwargs: dict[str, Any] = {arg_name: events}
-                if has_context and context is not None:
-                    kwargs["context"] = context
-                return fn(**kwargs)
-
             @functools.wraps(fn)
             def wrapper(*args: Any, **kwargs: Any) -> int:
-                # Extract the host trigger argument (e.g. timer) to pass
-                # to PollTrigger.run.  Support both positional and keyword.
                 timer: Any = None
                 if args:
                     timer = args[0]
                 elif host_params:
                     timer = kwargs.get(host_params[0])
+
+                bound_args = dict(kwargs)
+                if args and host_params:
+                    for i, val in enumerate(args):
+                        if i < len(host_params):
+                            bound_args[host_params[i]] = val
+
+                def invoke_handler(events: Any, context: Any | None = None) -> Any:
+                    call_kwargs: dict[str, Any] = dict(bound_args)
+                    call_kwargs[arg_name] = events
+                    if has_context and context is not None:
+                        call_kwargs["context"] = context
+                    return fn(**call_kwargs)
+
                 return trigger.run(timer=timer, handler=invoke_handler)
 
             # Keep host trigger params visible in __signature__ so Azure
@@ -287,7 +297,9 @@ class DbFunctionApp:
         engine_provider:
             Optional shared ``EngineProvider`` for connection pooling.
         """
-        # Validate mutual exclusion at call time (before decoration).
+        if on_not_found not in ("none", "raise"):
+            msg = f"db_input on_not_found must be 'none' or 'raise', got '{on_not_found}'"
+            raise ConfigurationError(msg)
         if pk is not None and query is not None:
             msg = "db_input requires exactly one of 'pk' or 'query', not both"
             raise ConfigurationError(msg)
@@ -325,8 +337,36 @@ class DbFunctionApp:
 
             is_async = asyncio.iscoroutinefunction(fn)
 
-            def _do_read(all_kwargs: dict[str, Any]) -> Any:
-                """Execute the DB read (runs in calling thread)."""
+            def _resolve_read_args(
+                all_kwargs: dict[str, Any],
+            ) -> tuple[dict[str, object] | None, dict[str, object] | None]:
+                """Resolve pk/params from handler kwargs (safe to call on any thread)."""
+                resolved_pk: dict[str, object] | None = None
+                resolved_params: dict[str, object] | None = None
+                if use_pk:
+                    if pk_callable is not None:
+                        resolved_pk = _resolve_callable(
+                            pk_callable, pk_resolver_params, all_kwargs
+                        )
+                    elif pk_static is not None:
+                        resolved_pk = pk_static
+                    else:
+                        msg = "db_input: unreachable – neither pk callable nor pk static"
+                        raise ConfigurationError(msg)
+                else:
+                    if params_callable is not None:
+                        resolved_params = _resolve_callable(
+                            params_callable, params_resolver_params, all_kwargs
+                        )
+                    elif params_static is not None:
+                        resolved_params = params_static
+                return resolved_pk, resolved_params
+
+            def _execute_read(
+                resolved_pk: dict[str, object] | None,
+                resolved_params: dict[str, object] | None,
+            ) -> Any:
+                """Execute DB I/O (blocking — run in worker thread for async)."""
                 reader = DbReader(
                     url=url,
                     table=table,
@@ -335,15 +375,8 @@ class DbFunctionApp:
                 )
                 try:
                     if use_pk:
-                        resolved_pk: dict[str, object]
-                        if pk_callable is not None:
-                            resolved_pk = _resolve_callable(
-                                pk_callable, pk_resolver_params, all_kwargs
-                            )
-                        elif pk_static is not None:
-                            resolved_pk = pk_static
-                        else:
-                            msg = "db_input: unreachable – neither pk callable nor pk static"
+                        if resolved_pk is None:
+                            msg = "db_input: unreachable – pk mode but resolved_pk is None"
                             raise ConfigurationError(msg)
                         result = reader.get(pk=resolved_pk)
                         if result is None and on_not_found == "raise":
@@ -353,13 +386,6 @@ class DbFunctionApp:
                             raise NotFoundError(msg)
                         return result
                     else:
-                        resolved_params: dict[str, object] | None = None
-                        if params_callable is not None:
-                            resolved_params = _resolve_callable(
-                                params_callable, params_resolver_params, all_kwargs
-                            )
-                        elif params_static is not None:
-                            resolved_params = params_static
                         if query is None:
                             msg = "db_input: unreachable – query mode but query is None"
                             raise ConfigurationError(msg)
@@ -371,7 +397,8 @@ class DbFunctionApp:
 
                 @functools.wraps(fn)
                 async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-                    data = await asyncio.to_thread(_do_read, kwargs)
+                    r_pk, r_params = _resolve_read_args(kwargs)
+                    data = await asyncio.to_thread(_execute_read, r_pk, r_params)
                     kwargs[arg_name] = data
                     return await fn(*args, **kwargs)
 
@@ -383,7 +410,8 @@ class DbFunctionApp:
 
             @functools.wraps(fn)
             def wrapper(*args: Any, **kwargs: Any) -> Any:
-                data = _do_read(kwargs)
+                r_pk, r_params = _resolve_read_args(kwargs)
+                data = _execute_read(r_pk, r_params)
                 kwargs[arg_name] = data
                 return fn(*args, **kwargs)
 
@@ -428,6 +456,9 @@ class DbFunctionApp:
         engine_provider:
             Optional shared ``EngineProvider`` for connection pooling.
         """
+        if action not in ("insert", "upsert"):
+            msg = f"db_output action must be 'insert' or 'upsert', got '{action}'"
+            raise ConfigurationError(msg)
         if action == "upsert" and not conflict_columns:
             msg = "db_output with action='upsert' requires 'conflict_columns'"
             raise ConfigurationError(msg)
@@ -456,6 +487,17 @@ class DbFunctionApp:
                         else:
                             writer.insert(data=result)
                     elif isinstance(result, list):
+                        bad = next(
+                            (i for i, row in enumerate(result) if not isinstance(row, dict)),
+                            None,
+                        )
+                        if bad is not None:
+                            bad_type = type(result[bad]).__name__
+                            msg = (
+                                f"db_output: handler returned list with non-dict element "
+                                f"at index {bad} ({bad_type}); expected list[dict]"
+                            )
+                            raise ConfigurationError(msg)
                         if action == "upsert":
                             if conflict_columns is None:
                                 msg = "db_output: unreachable – upsert without conflict_columns"

--- a/src/azure_functions_db/decorator.py
+++ b/src/azure_functions_db/decorator.py
@@ -340,9 +340,11 @@ class DbFunctionApp:
                             resolved_pk = _resolve_callable(
                                 pk_callable, pk_resolver_params, all_kwargs
                             )
-                        else:
-                            assert pk_static is not None
+                        elif pk_static is not None:
                             resolved_pk = pk_static
+                        else:
+                            msg = "db_input: unreachable – neither pk callable nor pk static"
+                            raise ConfigurationError(msg)
                         result = reader.get(pk=resolved_pk)
                         if result is None and on_not_found == "raise":
                             from .core.errors import NotFoundError
@@ -358,7 +360,9 @@ class DbFunctionApp:
                             )
                         elif params_static is not None:
                             resolved_params = params_static
-                        assert query is not None
+                        if query is None:
+                            msg = "db_input: unreachable – query mode but query is None"
+                            raise ConfigurationError(msg)
                         return reader.query(query, params=resolved_params)
                 finally:
                     reader.close()
@@ -445,13 +449,17 @@ class DbFunctionApp:
                 try:
                     if isinstance(result, dict):
                         if action == "upsert":
-                            assert conflict_columns is not None
+                            if conflict_columns is None:
+                                msg = "db_output: unreachable – upsert without conflict_columns"
+                                raise ConfigurationError(msg)
                             writer.upsert(data=result, conflict_columns=conflict_columns)
                         else:
                             writer.insert(data=result)
                     elif isinstance(result, list):
                         if action == "upsert":
-                            assert conflict_columns is not None
+                            if conflict_columns is None:
+                                msg = "db_output: unreachable – upsert without conflict_columns"
+                                raise ConfigurationError(msg)
                             writer.upsert_many(rows=result, conflict_columns=conflict_columns)
                         else:
                             writer.insert_many(rows=result)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -8,6 +8,7 @@ from sqlalchemy import create_engine, text
 from azure_functions_db import ConfigurationError, DbFunctionApp, NoOpCollector
 from azure_functions_db.binding.reader import DbReader
 from azure_functions_db.binding.writer import DbWriter
+from azure_functions_db.core.errors import NotFoundError
 from azure_functions_db.trigger.errors import FetchError
 from azure_functions_db.trigger.events import RowChange
 from tests.test_poll_trigger import FakeSourceAdapter, FakeStateStore
@@ -30,6 +31,28 @@ def _create_users_table(url: str) -> None:
         engine.dispose()
 
 
+def _create_users_table_with_data(url: str) -> None:
+    engine = create_engine(url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE TABLE users "
+                    "(id INTEGER PRIMARY KEY, name TEXT NOT NULL, active INTEGER NOT NULL)"
+                )
+            )
+            conn.execute(
+                text("INSERT INTO users (id, name, active) VALUES (:id, :name, :active)"),
+                [
+                    {"id": 1, "name": "Alice", "active": 1},
+                    {"id": 2, "name": "Bob", "active": 0},
+                    {"id": 3, "name": "Carol", "active": 1},
+                ],
+            )
+    finally:
+        engine.dispose()
+
+
 def _create_orders_table(url: str) -> None:
     engine = create_engine(url)
     try:
@@ -39,6 +62,21 @@ def _create_orders_table(url: str) -> None:
             )
     finally:
         engine.dispose()
+
+
+def _read_orders(url: str) -> list[dict[str, object]]:
+    engine = create_engine(url)
+    try:
+        with engine.connect() as conn:
+            result = conn.execute(text("SELECT id, status FROM processed_orders ORDER BY id"))
+            return [dict(row._mapping) for row in result]
+    finally:
+        engine.dispose()
+
+
+# =====================================================================
+# db_trigger tests (unchanged from previous version)
+# =====================================================================
 
 
 def test_db_trigger_returns_callable() -> None:
@@ -185,98 +223,7 @@ def test_db_trigger_accepts_metrics() -> None:
     assert handler(object()) == 1
 
 
-def test_db_input_injects_reader(tmp_path: Path) -> None:
-    url = _sqlite_url(tmp_path, "reader.db")
-    _create_users_table(url)
-
-    @DbFunctionApp().db_input("reader", url=url, table="users")
-    def handler(reader: DbReader) -> dict[str, object] | None:
-        return reader.get(pk={"id": 1})
-
-    assert handler() == {"id": 1, "name": "Alice"}
-
-
-def test_db_input_auto_closes_reader(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    url = _sqlite_url(tmp_path, "reader-close.db")
-    _create_users_table(url)
-    closed: list[DbReader] = []
-    original_close = DbReader.close
-
-    def tracking_close(self: DbReader) -> None:
-        closed.append(self)
-        original_close(self)
-
-    monkeypatch.setattr(DbReader, "close", tracking_close)
-
-    @DbFunctionApp().db_input("reader", url=url, table="users")
-    def handler(reader: DbReader) -> None:
-        assert reader.get(pk={"id": 1}) == {"id": 1, "name": "Alice"}
-
-    handler()
-
-    assert len(closed) == 1
-
-
-def test_db_input_invalid_arg_name_raises() -> None:
-    with pytest.raises(ConfigurationError, match="db_input arg_name='reader' not found"):
-
-        @DbFunctionApp().db_input("reader", url="sqlite:///unused.db", table="users")
-        def handler() -> None:
-            return None
-
-
-def test_db_output_injects_writer(tmp_path: Path) -> None:
-    url = _sqlite_url(tmp_path, "writer.db")
-    _create_orders_table(url)
-
-    @DbFunctionApp().db_output("writer", url=url, table="processed_orders")
-    def handler(writer: DbWriter) -> None:
-        writer.insert(data={"id": 1, "status": "processed"})
-
-    handler()
-
-    engine = create_engine(url)
-    try:
-        with engine.connect() as conn:
-            result = conn.execute(text("SELECT id, status FROM processed_orders ORDER BY id"))
-            rows = [dict(row._mapping) for row in result]
-    finally:
-        engine.dispose()
-
-    assert rows == [{"id": 1, "status": "processed"}]
-
-
-def test_db_output_auto_closes_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    url = _sqlite_url(tmp_path, "writer-close.db")
-    _create_orders_table(url)
-    closed: list[DbWriter] = []
-    original_close = DbWriter.close
-
-    def tracking_close(self: DbWriter) -> None:
-        closed.append(self)
-        original_close(self)
-
-    monkeypatch.setattr(DbWriter, "close", tracking_close)
-
-    @DbFunctionApp().db_output("writer", url=url, table="processed_orders")
-    def handler(writer: DbWriter) -> None:
-        writer.insert(data={"id": 1, "status": "processed"})
-
-    handler()
-
-    assert len(closed) == 1
-
-
-def test_db_output_invalid_arg_name_raises() -> None:
-    with pytest.raises(ConfigurationError, match="db_output arg_name='writer' not found"):
-
-        @DbFunctionApp().db_output("writer", url="sqlite:///unused.db", table="processed")
-        def handler() -> None:
-            return None
-
-
 def test_db_trigger_signature_preserves_host_params() -> None:
-    """Host trigger params (e.g. timer) must stay visible in __signature__."""
     import inspect
 
     @DbFunctionApp().db_trigger(
@@ -292,9 +239,508 @@ def test_db_trigger_signature_preserves_host_params() -> None:
     assert "events" not in sig.parameters
 
 
+def test_db_trigger_reserved_arg_name_raises() -> None:
+    with pytest.raises(ConfigurationError, match="conflicts with Azure Functions"):
+
+        @DbFunctionApp().db_trigger(
+            arg_name="timer",
+            source=FakeSourceAdapter(batches=[]),
+            checkpoint_store=FakeStateStore(),
+        )
+        def handler(timer: object) -> None:
+            del timer
+
+
+# =====================================================================
+# db_input tests — data injection
+# =====================================================================
+
+
+def test_db_input_pk_static_returns_row(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "input-pk-static.db")
+    _create_users_table(url)
+
+    @DbFunctionApp().db_input("user", url=url, table="users", pk={"id": 1})
+    def handler(user: dict[str, object] | None) -> dict[str, object] | None:
+        return user
+
+    assert handler() == {"id": 1, "name": "Alice"}
+
+
+def test_db_input_pk_static_returns_none_when_not_found(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "input-pk-none.db")
+    _create_users_table(url)
+
+    @DbFunctionApp().db_input("user", url=url, table="users", pk={"id": 999})
+    def handler(user: dict[str, object] | None) -> dict[str, object] | None:
+        return user
+
+    assert handler() is None
+
+
+def test_db_input_pk_callable_resolves_from_kwargs(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "input-pk-callable.db")
+    _create_users_table(url)
+
+    class FakeReq:
+        def __init__(self, user_id: int) -> None:
+            self.user_id = user_id
+
+    @DbFunctionApp().db_input("user", url=url, table="users", pk=lambda req: {"id": req.user_id})
+    def handler(req: FakeReq, user: dict[str, object] | None) -> dict[str, object] | None:
+        return user
+
+    assert handler(req=FakeReq(1)) == {"id": 1, "name": "Alice"}
+    assert handler(req=FakeReq(999)) is None
+
+
+def test_db_input_on_not_found_raise(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "input-not-found-raise.db")
+    _create_users_table(url)
+
+    @DbFunctionApp().db_input("user", url=url, table="users", pk={"id": 999}, on_not_found="raise")
+    def handler(user: dict[str, object]) -> dict[str, object]:
+        return user
+
+    with pytest.raises(NotFoundError, match="no row found"):
+        handler()
+
+
+def test_db_input_query_static_returns_rows(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "input-query-static.db")
+    _create_users_table(url)
+
+    @DbFunctionApp().db_input("users", url=url, query="SELECT id, name FROM users ORDER BY id")
+    def handler(users: list[dict[str, object]]) -> list[dict[str, object]]:
+        return users
+
+    assert handler() == [{"id": 1, "name": "Alice"}]
+
+
+def test_db_input_query_with_static_params(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "input-query-params.db")
+    _create_users_table_with_data(url)
+
+    @DbFunctionApp().db_input(
+        "users",
+        url=url,
+        query="SELECT id, name FROM users WHERE active = :active ORDER BY id",
+        params={"active": 1},
+    )
+    def handler(users: list[dict[str, object]]) -> list[dict[str, object]]:
+        return users
+
+    result = handler()
+    assert len(result) == 2
+    assert result[0]["name"] == "Alice"
+    assert result[1]["name"] == "Carol"
+
+
+def test_db_input_query_with_callable_params(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "input-query-callable-params.db")
+    _create_users_table_with_data(url)
+
+    class FakeReq:
+        def __init__(self, active: int) -> None:
+            self.active = active
+
+    @DbFunctionApp().db_input(
+        "users",
+        url=url,
+        query="SELECT id, name FROM users WHERE active = :active ORDER BY id",
+        params=lambda req: {"active": req.active},
+    )
+    def handler(req: FakeReq, users: list[dict[str, object]]) -> list[dict[str, object]]:
+        return users
+
+    result = handler(req=FakeReq(0))
+    assert len(result) == 1
+    assert result[0]["name"] == "Bob"
+
+
+def test_db_input_query_returns_empty_list(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "input-query-empty.db")
+    _create_users_table(url)
+
+    @DbFunctionApp().db_input(
+        "users",
+        url=url,
+        query="SELECT id, name FROM users WHERE id = :id",
+        params={"id": 999},
+    )
+    def handler(users: list[dict[str, object]]) -> list[dict[str, object]]:
+        return users
+
+    assert handler() == []
+
+
+def test_db_input_auto_closes_reader(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    url = _sqlite_url(tmp_path, "input-close.db")
+    _create_users_table(url)
+    closed: list[DbReader] = []
+    original_close = DbReader.close
+
+    def tracking_close(self: DbReader) -> None:
+        closed.append(self)
+        original_close(self)
+
+    monkeypatch.setattr(DbReader, "close", tracking_close)
+
+    @DbFunctionApp().db_input("user", url=url, table="users", pk={"id": 1})
+    def handler(user: dict[str, object] | None) -> None:
+        pass
+
+    handler()
+
+    assert len(closed) == 1
+
+
+def test_db_input_invalid_arg_name_raises() -> None:
+    with pytest.raises(ConfigurationError, match="db_input arg_name='user' not found"):
+
+        @DbFunctionApp().db_input("user", url="sqlite:///unused.db", table="users", pk={"id": 1})
+        def handler() -> None:
+            return None
+
+
+def test_db_input_requires_pk_or_query() -> None:
+    with pytest.raises(ConfigurationError, match="exactly one of 'pk' or 'query'"):
+        DbFunctionApp().db_input("data", url="sqlite:///unused.db")
+
+
+def test_db_input_rejects_both_pk_and_query() -> None:
+    with pytest.raises(ConfigurationError, match="not both"):
+        DbFunctionApp().db_input(
+            "data", url="sqlite:///unused.db", table="t", pk={"id": 1}, query="SELECT 1"
+        )
+
+
+def test_db_input_pk_requires_table() -> None:
+    with pytest.raises(ConfigurationError, match="requires 'table'"):
+        DbFunctionApp().db_input("data", url="sqlite:///unused.db", pk={"id": 1})
+
+
+def test_db_input_params_requires_query() -> None:
+    with pytest.raises(ConfigurationError, match="only valid with 'query'"):
+        DbFunctionApp().db_input(
+            "data", url="sqlite:///unused.db", table="t", pk={"id": 1}, params={"x": 1}
+        )
+
+
+def test_db_input_resolver_rejects_var_args() -> None:
+    with pytest.raises(ConfigurationError, match="must not use \\*args or \\*\\*kwargs"):
+
+        @DbFunctionApp().db_input(
+            "user",
+            url="sqlite:///unused.db",
+            table="users",
+            pk=lambda *args: {"id": 1},
+        )
+        def handler(req: object, user: object) -> None:
+            pass
+
+
+def test_db_input_resolver_rejects_unknown_params() -> None:
+    with pytest.raises(ConfigurationError, match="references parameters.*not found"):
+
+        @DbFunctionApp().db_input(
+            "user",
+            url="sqlite:///unused.db",
+            table="users",
+            pk=lambda unknown: {"id": 1},
+        )
+        def handler(req: object, user: object) -> None:
+            pass
+
+
+def test_db_input_preserves_function_name(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "input-name.db")
+    _create_users_table(url)
+
+    @DbFunctionApp().db_input("user", url=url, table="users", pk={"id": 1})
+    def my_handler(user: dict[str, object] | None) -> None:
+        pass
+
+    assert my_handler.__name__ == "my_handler"
+
+
+def test_db_input_hides_arg_from_signature(tmp_path: Path) -> None:
+    import inspect
+
+    url = _sqlite_url(tmp_path, "input-sig.db")
+    _create_users_table(url)
+
+    @DbFunctionApp().db_input("user", url=url, table="users", pk={"id": 1})
+    def handler(req: object, user: dict[str, object] | None) -> None:
+        pass
+
+    sig = inspect.signature(handler)
+    assert "req" in sig.parameters
+    assert "user" not in sig.parameters
+
+
+# =====================================================================
+# db_output tests — return-value auto-write
+# =====================================================================
+
+
+def test_db_output_insert_dict(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "output-insert-dict.db")
+    _create_orders_table(url)
+
+    @DbFunctionApp().db_output(url=url, table="processed_orders")
+    def handler() -> dict[str, object]:
+        return {"id": 1, "status": "done"}
+
+    result = handler()
+
+    assert result == {"id": 1, "status": "done"}
+    assert _read_orders(url) == [{"id": 1, "status": "done"}]
+
+
+def test_db_output_insert_list(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "output-insert-list.db")
+    _create_orders_table(url)
+
+    @DbFunctionApp().db_output(url=url, table="processed_orders")
+    def handler() -> list[dict[str, object]]:
+        return [
+            {"id": 1, "status": "a"},
+            {"id": 2, "status": "b"},
+        ]
+
+    result = handler()
+
+    assert len(result) == 2
+    assert _read_orders(url) == [{"id": 1, "status": "a"}, {"id": 2, "status": "b"}]
+
+
+def test_db_output_none_is_noop(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "output-none.db")
+    _create_orders_table(url)
+
+    @DbFunctionApp().db_output(url=url, table="processed_orders")
+    def handler() -> None:
+        return None
+
+    handler()
+
+    assert _read_orders(url) == []
+
+
+def test_db_output_upsert_dict(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "output-upsert-dict.db")
+    _create_orders_table(url)
+
+    db = DbFunctionApp()
+
+    @db.db_output(url=url, table="processed_orders", action="upsert", conflict_columns=["id"])
+    def handler() -> dict[str, object]:
+        return {"id": 1, "status": "first"}
+
+    handler()
+    assert _read_orders(url) == [{"id": 1, "status": "first"}]
+
+    @db.db_output(url=url, table="processed_orders", action="upsert", conflict_columns=["id"])
+    def handler2() -> dict[str, object]:
+        return {"id": 1, "status": "updated"}
+
+    handler2()
+    assert _read_orders(url) == [{"id": 1, "status": "updated"}]
+
+
+def test_db_output_upsert_list(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "output-upsert-list.db")
+    _create_orders_table(url)
+
+    @DbFunctionApp().db_output(
+        url=url, table="processed_orders", action="upsert", conflict_columns=["id"]
+    )
+    def handler() -> list[dict[str, object]]:
+        return [{"id": 1, "status": "a"}, {"id": 2, "status": "b"}]
+
+    handler()
+    assert _read_orders(url) == [{"id": 1, "status": "a"}, {"id": 2, "status": "b"}]
+
+
+def test_db_output_upsert_requires_conflict_columns() -> None:
+    with pytest.raises(ConfigurationError, match="requires 'conflict_columns'"):
+        DbFunctionApp().db_output(url="sqlite:///unused.db", table="t", action="upsert")
+
+
+def test_db_output_rejects_invalid_return_type(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "output-invalid.db")
+    _create_orders_table(url)
+
+    @DbFunctionApp().db_output(url=url, table="processed_orders")
+    def handler() -> str:
+        return "not a dict"
+
+    with pytest.raises(ConfigurationError, match="expected dict, list"):
+        handler()
+
+
+def test_db_output_auto_closes_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    url = _sqlite_url(tmp_path, "output-close.db")
+    _create_orders_table(url)
+    closed: list[DbWriter] = []
+    original_close = DbWriter.close
+
+    def tracking_close(self: DbWriter) -> None:
+        closed.append(self)
+        original_close(self)
+
+    monkeypatch.setattr(DbWriter, "close", tracking_close)
+
+    @DbFunctionApp().db_output(url=url, table="processed_orders")
+    def handler() -> dict[str, object]:
+        return {"id": 1, "status": "done"}
+
+    handler()
+
+    assert len(closed) == 1
+
+
+def test_db_output_preserves_function_name() -> None:
+    @DbFunctionApp().db_output(url="sqlite:///unused.db", table="t")
+    def my_handler() -> None:
+        return None
+
+    assert my_handler.__name__ == "my_handler"
+
+
+def test_db_output_returns_original_value(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "output-return.db")
+    _create_orders_table(url)
+
+    @DbFunctionApp().db_output(url=url, table="processed_orders")
+    def handler() -> dict[str, object]:
+        return {"id": 1, "status": "done"}
+
+    result = handler()
+    assert result == {"id": 1, "status": "done"}
+
+
+# =====================================================================
+# db_reader tests — client injection (imperative escape hatch)
+# =====================================================================
+
+
+def test_db_reader_injects_reader(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "reader.db")
+    _create_users_table(url)
+
+    @DbFunctionApp().db_reader("reader", url=url, table="users")
+    def handler(reader: DbReader) -> dict[str, object] | None:
+        return reader.get(pk={"id": 1})
+
+    assert handler() == {"id": 1, "name": "Alice"}
+
+
+def test_db_reader_auto_closes_reader(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    url = _sqlite_url(tmp_path, "reader-close.db")
+    _create_users_table(url)
+    closed: list[DbReader] = []
+    original_close = DbReader.close
+
+    def tracking_close(self: DbReader) -> None:
+        closed.append(self)
+        original_close(self)
+
+    monkeypatch.setattr(DbReader, "close", tracking_close)
+
+    @DbFunctionApp().db_reader("reader", url=url, table="users")
+    def handler(reader: DbReader) -> None:
+        assert reader.get(pk={"id": 1}) == {"id": 1, "name": "Alice"}
+
+    handler()
+
+    assert len(closed) == 1
+
+
+def test_db_reader_invalid_arg_name_raises() -> None:
+    with pytest.raises(ConfigurationError, match="db_reader arg_name='reader' not found"):
+
+        @DbFunctionApp().db_reader("reader", url="sqlite:///unused.db", table="users")
+        def handler() -> None:
+            return None
+
+
+# =====================================================================
+# db_writer tests — client injection (imperative escape hatch)
+# =====================================================================
+
+
+def test_db_writer_injects_writer(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "writer.db")
+    _create_orders_table(url)
+
+    @DbFunctionApp().db_writer("writer", url=url, table="processed_orders")
+    def handler(writer: DbWriter) -> None:
+        writer.insert(data={"id": 1, "status": "processed"})
+
+    handler()
+
+    assert _read_orders(url) == [{"id": 1, "status": "processed"}]
+
+
+def test_db_writer_auto_closes_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    url = _sqlite_url(tmp_path, "writer-close.db")
+    _create_orders_table(url)
+    closed: list[DbWriter] = []
+    original_close = DbWriter.close
+
+    def tracking_close(self: DbWriter) -> None:
+        closed.append(self)
+        original_close(self)
+
+    monkeypatch.setattr(DbWriter, "close", tracking_close)
+
+    @DbFunctionApp().db_writer("writer", url=url, table="processed_orders")
+    def handler(writer: DbWriter) -> None:
+        writer.insert(data={"id": 1, "status": "processed"})
+
+    handler()
+
+    assert len(closed) == 1
+
+
+def test_db_writer_invalid_arg_name_raises() -> None:
+    with pytest.raises(ConfigurationError, match="db_writer arg_name='writer' not found"):
+
+        @DbFunctionApp().db_writer("writer", url="sqlite:///unused.db", table="processed")
+        def handler() -> None:
+            return None
+
+
+# =====================================================================
+# Stacking tests
+# =====================================================================
+
+
 def test_db_trigger_stacked_with_db_output(tmp_path: Path) -> None:
-    """db_trigger + db_output stacking: events and writer both injected."""
-    url = _sqlite_url(tmp_path, "stack.db")
+    url = _sqlite_url(tmp_path, "stack-trigger-output.db")
+    _create_orders_table(url)
+
+    db = DbFunctionApp()
+
+    @db.db_trigger(
+        arg_name="events",
+        source=FakeSourceAdapter(batches=[[{"id": 1, "updated_at": 100}]]),
+        checkpoint_store=FakeStateStore(),
+    )
+    @db.db_output(url=url, table="processed_orders")
+    def handler(events: list[RowChange]) -> list[dict[str, object]]:
+        return [{"id": e.pk["id"], "status": "done"} for e in events]
+
+    result = handler(object())
+
+    assert result == 1
+    assert _read_orders(url) == [{"id": 1, "status": "done"}]
+
+
+def test_db_trigger_stacked_with_db_writer(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "stack-trigger-writer.db")
     _create_orders_table(url)
 
     db = DbFunctionApp()
@@ -305,7 +751,7 @@ def test_db_trigger_stacked_with_db_output(tmp_path: Path) -> None:
         source=FakeSourceAdapter(batches=[[{"id": 1, "updated_at": 100}]]),
         checkpoint_store=FakeStateStore(),
     )
-    @db.db_output("writer", url=url, table="processed_orders")
+    @db.db_writer("writer", url=url, table="processed_orders")
     def handler(events: list[RowChange], writer: DbWriter) -> None:
         captured["events_count"] = len(events)
         captured["has_writer"] = writer is not None
@@ -319,7 +765,6 @@ def test_db_trigger_stacked_with_db_output(tmp_path: Path) -> None:
 
 
 def test_db_trigger_stacked_signature_hides_db_params() -> None:
-    """When stacked, final __signature__ should only show host params."""
     import inspect
 
     db = DbFunctionApp()
@@ -329,7 +774,7 @@ def test_db_trigger_stacked_signature_hides_db_params() -> None:
         source=FakeSourceAdapter(batches=[]),
         checkpoint_store=FakeStateStore(),
     )
-    @db.db_output("writer", url="sqlite:///unused.db", table="t")
+    @db.db_writer("writer", url="sqlite:///unused.db", table="t")
     def handler(timer: object, events: list[RowChange], writer: DbWriter) -> None:
         del timer, events, writer
 
@@ -340,8 +785,7 @@ def test_db_trigger_stacked_signature_hides_db_params() -> None:
     assert "writer" not in param_names
 
 
-def test_db_trigger_rejects_async_db_output_wrapper() -> None:
-    """db_trigger must reject async-wrapped inner decorators."""
+def test_db_trigger_rejects_async_db_writer_wrapper() -> None:
     db = DbFunctionApp()
 
     with pytest.raises(ConfigurationError, match="does not support async"):
@@ -351,18 +795,27 @@ def test_db_trigger_rejects_async_db_output_wrapper() -> None:
             source=FakeSourceAdapter(batches=[]),
             checkpoint_store=FakeStateStore(),
         )
-        @db.db_output("writer", url="sqlite:///unused.db", table="t")
+        @db.db_writer("writer", url="sqlite:///unused.db", table="t")
         async def handler(events: list[RowChange], writer: DbWriter) -> None:
             del events, writer
 
 
-def test_db_trigger_reserved_arg_name_raises() -> None:
-    with pytest.raises(ConfigurationError, match="conflicts with Azure Functions"):
+def test_db_input_stacked_with_db_output(tmp_path: Path) -> None:
+    url_read = _sqlite_url(tmp_path, "stack-input-read.db")
+    url_write = _sqlite_url(tmp_path, "stack-input-write.db")
+    _create_users_table(url_read)
+    _create_orders_table(url_write)
 
-        @DbFunctionApp().db_trigger(
-            arg_name="timer",
-            source=FakeSourceAdapter(batches=[]),
-            checkpoint_store=FakeStateStore(),
-        )
-        def handler(timer: object) -> None:
-            del timer
+    db = DbFunctionApp()
+
+    @db.db_input("user", url=url_read, table="users", pk={"id": 1})
+    @db.db_output(url=url_write, table="processed_orders")
+    def handler(user: dict[str, object] | None) -> dict[str, object] | None:
+        if user is None:
+            return None
+        return {"id": user["id"], "status": "processed"}
+
+    result = handler()
+
+    assert result == {"id": 1, "status": "processed"}
+    assert _read_orders(url_write) == [{"id": 1, "status": "processed"}]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -819,3 +819,208 @@ def test_db_input_stacked_with_db_output(tmp_path: Path) -> None:
 
     assert result == {"id": 1, "status": "processed"}
     assert _read_orders(url_write) == [{"id": 1, "status": "processed"}]
+
+
+# =====================================================================
+# Review feedback: validation, positional args, host param forwarding
+# =====================================================================
+
+
+def test_db_input_resolver_rejects_positional_only_params() -> None:
+    def resolver(x: int, /) -> dict[str, object]:
+        return {"id": x}
+
+    with pytest.raises(ConfigurationError, match="positional-only"):
+
+        @DbFunctionApp().db_input(
+            "user",
+            url="sqlite:///unused.db",
+            table="users",
+            pk=resolver,
+        )
+        def handler(x: int, user: object) -> None:
+            pass
+
+
+def test_db_input_invalid_on_not_found_raises() -> None:
+    with pytest.raises(ConfigurationError, match="on_not_found must be"):
+        DbFunctionApp().db_input(
+            "user",
+            url="sqlite:///unused.db",
+            table="users",
+            pk={"id": 1},
+            on_not_found="bogus",  # type: ignore[arg-type]
+        )
+
+
+def test_db_output_invalid_action_raises() -> None:
+    with pytest.raises(ConfigurationError, match="action must be"):
+        DbFunctionApp().db_output(
+            url="sqlite:///unused.db",
+            table="t",
+            action="bogus",  # type: ignore[arg-type]
+        )
+
+
+def test_db_output_rejects_invalid_list_elements(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "output-bad-list.db")
+    _create_orders_table(url)
+
+    @DbFunctionApp().db_output(url=url, table="processed_orders")
+    def handler() -> list[object]:
+        return [{"id": 1, "status": "ok"}, "not_a_dict"]  # type: ignore[return-value]
+
+    with pytest.raises(ConfigurationError, match="non-dict element at index 1"):
+        handler()
+
+
+def test_db_trigger_forwards_host_params_at_runtime() -> None:
+    received: dict[str, object] = {}
+    host_timer = object()
+
+    @DbFunctionApp().db_trigger(
+        arg_name="events",
+        source=FakeSourceAdapter(batches=[[{"id": 1, "updated_at": 100}]]),
+        checkpoint_store=FakeStateStore(),
+    )
+    def handler(timer: object, events: list[RowChange]) -> None:
+        received["timer"] = timer
+        received["events_count"] = len(events)
+
+    handler(host_timer)
+
+    assert received["timer"] is host_timer
+    assert received["events_count"] == 1
+
+
+def test_db_trigger_forwards_host_params_with_db_output(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "trigger-host-output.db")
+    _create_orders_table(url)
+    received: dict[str, object] = {}
+    host_timer = object()
+
+    db = DbFunctionApp()
+
+    @db.db_trigger(
+        arg_name="events",
+        source=FakeSourceAdapter(batches=[[{"id": 1, "updated_at": 100}]]),
+        checkpoint_store=FakeStateStore(),
+    )
+    @db.db_output(url=url, table="processed_orders")
+    def handler(timer: object, events: list[RowChange]) -> list[dict[str, object]]:
+        received["timer"] = timer
+        return [{"id": e.pk["id"], "status": "done"} for e in events]
+
+    result = handler(host_timer)
+
+    assert result == 1
+    assert received["timer"] is host_timer
+    assert _read_orders(url) == [{"id": 1, "status": "done"}]
+
+
+# =====================================================================
+# Async decorator tests
+# =====================================================================
+
+
+def test_db_input_async_pk_static(tmp_path: Path) -> None:
+    import asyncio
+
+    url = _sqlite_url(tmp_path, "async-input-pk.db")
+    _create_users_table(url)
+
+    @DbFunctionApp().db_input("user", url=url, table="users", pk={"id": 1})
+    async def handler(user: dict[str, object] | None) -> dict[str, object] | None:
+        return user
+
+    assert asyncio.run(handler()) == {"id": 1, "name": "Alice"}
+
+
+def test_db_input_async_query(tmp_path: Path) -> None:
+    import asyncio
+
+    url = _sqlite_url(tmp_path, "async-input-query.db")
+    _create_users_table(url)
+
+    @DbFunctionApp().db_input("users", url=url, query="SELECT id, name FROM users ORDER BY id")
+    async def handler(users: list[dict[str, object]]) -> list[dict[str, object]]:
+        return users
+
+    assert asyncio.run(handler()) == [{"id": 1, "name": "Alice"}]
+
+
+def test_db_input_async_pk_callable(tmp_path: Path) -> None:
+    import asyncio
+
+    url = _sqlite_url(tmp_path, "async-input-pk-callable.db")
+    _create_users_table(url)
+
+    class FakeReq:
+        def __init__(self, user_id: int) -> None:
+            self.user_id = user_id
+
+    @DbFunctionApp().db_input("user", url=url, table="users", pk=lambda req: {"id": req.user_id})
+    async def handler(req: FakeReq, user: dict[str, object] | None) -> dict[str, object] | None:
+        return user
+
+    assert asyncio.run(handler(req=FakeReq(1))) == {"id": 1, "name": "Alice"}
+    assert asyncio.run(handler(req=FakeReq(999))) is None
+
+
+def test_db_output_async_insert(tmp_path: Path) -> None:
+    import asyncio
+
+    url = _sqlite_url(tmp_path, "async-output-insert.db")
+    _create_orders_table(url)
+
+    @DbFunctionApp().db_output(url=url, table="processed_orders")
+    async def handler() -> dict[str, object]:
+        return {"id": 1, "status": "async_done"}
+
+    result = asyncio.run(handler())
+
+    assert result == {"id": 1, "status": "async_done"}
+    assert _read_orders(url) == [{"id": 1, "status": "async_done"}]
+
+
+def test_db_output_async_none_is_noop(tmp_path: Path) -> None:
+    import asyncio
+
+    url = _sqlite_url(tmp_path, "async-output-none.db")
+    _create_orders_table(url)
+
+    @DbFunctionApp().db_output(url=url, table="processed_orders")
+    async def handler() -> None:
+        return None
+
+    asyncio.run(handler())
+
+    assert _read_orders(url) == []
+
+
+def test_db_reader_async_injects_reader(tmp_path: Path) -> None:
+    import asyncio
+
+    url = _sqlite_url(tmp_path, "async-reader.db")
+    _create_users_table(url)
+
+    @DbFunctionApp().db_reader("reader", url=url, table="users")
+    async def handler(reader: DbReader) -> dict[str, object] | None:
+        return reader.get(pk={"id": 1})
+
+    assert asyncio.run(handler()) == {"id": 1, "name": "Alice"}
+
+
+def test_db_writer_async_injects_writer(tmp_path: Path) -> None:
+    import asyncio
+
+    url = _sqlite_url(tmp_path, "async-writer.db")
+    _create_orders_table(url)
+
+    @DbFunctionApp().db_writer("writer", url=url, table="processed_orders")
+    async def handler(writer: DbWriter) -> None:
+        writer.insert(data={"id": 1, "status": "async_written"})
+
+    asyncio.run(handler())
+
+    assert _read_orders(url) == [{"id": 1, "status": "async_written"}]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -868,7 +868,7 @@ def test_db_output_rejects_invalid_list_elements(tmp_path: Path) -> None:
 
     @DbFunctionApp().db_output(url=url, table="processed_orders")
     def handler() -> list[object]:
-        return [{"id": 1, "status": "ok"}, "not_a_dict"]  # type: ignore[return-value]
+        return [{"id": 1, "status": "ok"}, "not_a_dict"]
 
     with pytest.raises(ConfigurationError, match="non-dict element at index 1"):
         handler()


### PR DESCRIPTION
## Summary

Redesigns `db_input` and `db_output` decorators from **client injection** (injecting `DbReader`/`DbWriter` instances) to **data injection** (injecting actual query results / auto-writing return values), matching how Azure's native bindings work.

### Changes

**`db_input` — data injection:**
- Handler parameter receives actual data, not a `DbReader`
- PK mode: `pk=dict | Callable` → injects `dict | None`
- Query mode: `query=str, params=dict | Callable` → injects `list[dict]`
- Resolver callables validated at decoration time (param names must match handler)
- Configurable `on_not_found="none" | "raise"`
- Async handlers use `asyncio.to_thread` for DB I/O

**`db_output` — return-value auto-write:**
- No `arg_name` needed — handler return value is auto-written
- `dict` → single insert, `list[dict]` → batch, `None` → no-op
- `action="insert"` (default) or `action="upsert"` with `conflict_columns`
- Returns original value for downstream decorator compatibility

**`db_reader` / `db_writer` — imperative escape hatches:**
- Renamed from the old `db_input`/`db_output` client injection
- Same behavior: inject `DbReader`/`DbWriter` per invocation with auto-close
- For complex operations: multiple queries, transactions, update/delete

### Files changed (6)
- `src/azure_functions_db/decorator.py` — core redesign
- `tests/test_decorator.py` — 51 test cases covering all modes
- `examples/trigger_with_binding/function_app.py` — shows both patterns
- `README.md` — updated API docs
- `docs/04-python-api-spec.md` — updated API reference
- `docs/22-binding-semantics.md` — updated binding semantics

### Testing
- 435 tests pass (full suite)
- mypy clean on `decorator.py`
- ruff lint + format clean