### PR TITLE
docs: align documentation structure with sibling repos

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,60 @@
+# Changelog
+
+This page documents the version history and migration paths for the `azure-functions-db` package.
+
+## Versioning Scheme
+
+This project follows Semantic Versioning (semver.org). Given a version number MAJOR.MINOR.PATCH, increment the:
+
+- MAJOR version when you make incompatible API changes
+- MINOR version when you add functionality in a backward compatible manner
+- PATCH version when you make backward compatible bug fixes
+
+The changelog is generated from Conventional Commits using git-cliff. Breaking changes are explicitly listed under the "Breaking Changes" section for each release.
+
+## Full Version History
+
+### Unreleased (post-0.1.0)
+
+The following changes have been merged to `main` but are not yet released. Breaking changes are acceptable — this is a pre-1.0 package with no external users.
+
+#### Breaking Changes
+
+- Renamed `DbFunctionApp` to `DbBindings` (#33)
+- Dropped `db_` prefix from all decorators: `trigger`, `input`, `output`, `inject_reader`, `inject_writer` (#41, #45)
+- Replaced `OutputResult` with `DbOut` class using `.set()` pattern (#50)
+- Narrowed public exports to 27 stable symbols (#34)
+
+#### Features
+
+- Added `input` decorator for data injection with row lookup and query modes (#35)
+- Added `output` decorator for declarative writes with `DbOut` (#35, #50)
+- Added `inject_reader`/`inject_writer` for imperative client injection (#35)
+- Added decorator composition validation with mutual exclusivity rules (#43)
+- Added partial env var substitution for connection URLs (#39)
+- Added `engine_kwargs` passthrough on all decorators (#40)
+- Added `EngineProvider` for shared connection pooling
+
+#### Documentation
+
+- Added async support matrix documentation (#37)
+- Added input mode (row lookup / query) documentation (#36)
+- Added lifecycle and thread-safety documentation (#44)
+- Updated README with ecosystem branding (#42)
+- Aligned documentation structure with sibling repos
+
+### v0.1.0 (2025-04-08)
+
+#### Features
+
+- Add MetricsCollector, structured logging, and lag calculation (#21)
+- Add PollTrigger, `db.poll()` decorator, and normalizers (#20)
+- Add SqlAlchemySource with cursor-based polling (#19)
+- Add BlobCheckpointStore with ETag-based CAS leasing (#18)
+- Core types, errors, trigger events, context, retry, and runner (#17)
+- Initial project scaffold — unified DB integration framework for Azure Functions Python v2
+
+#### Documentation
+
+- Translate docs to English and align README with series style (#16)
+- Release process documentation and CI/CD workflow fixes (#22)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,86 @@
+# Contributing
+
+Thank you for considering contributing to `azure-functions-db`.
+
+## Development Setup
+
+```bash
+git clone https://github.com/yeongseon/azure-functions-db.git
+cd azure-functions-db
+make install
+```
+
+Requirements:
+
+- Python 3.11+
+- [hatch](https://hatch.pypa.io/) for build and version management
+- [Ruff](https://docs.astral.sh/ruff/) for linting and formatting
+- [mypy](https://mypy-lang.org/) for type checking
+
+## Running Checks
+
+```bash
+make test        # Run all tests
+make lint        # Run Ruff linter
+make typecheck   # Run mypy
+make build       # Verify package builds
+```
+
+Or run everything at once:
+
+```bash
+make check-all
+```
+
+## Branch Naming
+
+Use the following prefixes:
+
+- `feature/*` — new functionality
+- `fix/*` — bug fixes
+- `docs/*` — documentation changes
+- `adr/*` — architecture decision records
+
+## Pull Request Guidelines
+
+Every PR should address:
+
+1. **What** is being changed.
+2. **Why** it is needed.
+3. **Semantics impact** — does this change delivery guarantees or API contracts?
+4. **Migration** — is a migration required for existing users?
+5. **Tests** — are tests added or updated?
+
+## Code Style
+
+- Python type hints required on all public APIs.
+- Public surface docstrings required (Google style).
+- Use structured logging — no `print` statements (except in examples).
+- No direct SQL string concatenation.
+- Ruff configuration: `select = ["E", "F", "I"]`, `line-length = 100`.
+- Never suppress type errors with `as any`, `@ts-ignore`, or `type: ignore`.
+
+## Documentation
+
+- Keep README, PRD, and semantics documents consistent with each other.
+- New features must include example updates.
+- Semantics changes require an ADR (Architecture Decision Record).
+- User-facing docs must always preserve this statement:
+
+> pseudo trigger / at-least-once / idempotent handler required
+
+## Test Requirements
+
+- Unit tests for all new code.
+- Adapter changes must include integration tests.
+- Lease and checkpoint changes must include race condition tests.
+- Coverage threshold: 90%.
+
+See [Testing](testing.md) for details on running and writing tests.
+
+## Principles
+
+- PRs that change semantics must include an ADR or design note.
+- New adapters may not be merged without contract tests.
+- Public API additions must be accompanied by docs and example updates.
+- Do not use language that overstates guarantees.

--- a/docs/examples/client_injection.md
+++ b/docs/examples/client_injection.md
@@ -1,0 +1,145 @@
+# Client Injection
+
+For complex operations that go beyond simple reads or writes, use
+`inject_reader` and `inject_writer` to get client instances with full
+imperative control.
+
+## When to Use
+
+Use client injection instead of `input`/`output` when you need:
+
+- Multiple queries in one handler
+- Transactions or conditional logic
+- Update or delete operations
+- Fine-grained error handling per operation
+
+## inject_reader
+
+Inject a `DbReader` instance for read operations:
+
+```python
+from azure_functions_db import DbBindings, DbReader
+
+db = DbBindings()
+
+
+@db.inject_reader("reader", url="%DB_URL%", table="users")
+def complex_read(reader: DbReader) -> None:
+    # Single row lookup
+    user = reader.get(pk={"id": 42})
+
+    # SQL query with parameters
+    orders = reader.query(
+        "SELECT * FROM orders WHERE user_id = :uid AND status = :status",
+        params={"uid": 42, "status": "pending"},
+    )
+
+    for order in orders:
+        print(order["id"], order["total"])
+```
+
+### DbReader Methods
+
+| Method | Description |
+| --- | --- |
+| `get(pk={...})` | Fetch a single row by primary key. Returns `dict \| None`. |
+| `query(sql, params={...})` | Execute a SQL query. Returns `list[dict]`. |
+
+## inject_writer
+
+Inject a `DbWriter` instance for write operations:
+
+```python
+from azure_functions_db import DbBindings, DbWriter
+
+db = DbBindings()
+
+
+@db.inject_writer("writer", url="%DB_URL%", table="orders")
+def complex_write(writer: DbWriter) -> None:
+    # Insert
+    writer.insert(data={"id": 1, "status": "pending", "total": 99.99})
+
+    # Update
+    writer.update(data={"status": "shipped"}, pk={"id": 1})
+
+    # Upsert
+    writer.upsert(
+        data={"id": 2, "status": "pending", "total": 49.99},
+        conflict_columns=["id"],
+    )
+
+    # Delete
+    writer.delete(pk={"id": 1})
+```
+
+### DbWriter Methods
+
+| Method | Description |
+| --- | --- |
+| `insert(data={...})` | Insert a single row. |
+| `update(data={...}, pk={...})` | Update a row by primary key. |
+| `upsert(data={...}, conflict_columns=[...])` | Insert or update on conflict. |
+| `delete(pk={...})` | Delete a row by primary key. |
+
+## Combined Reader + Writer
+
+Use both on the same handler for read-then-write workflows:
+
+```python
+from azure_functions_db import DbBindings, DbReader, DbWriter
+
+db = DbBindings()
+
+
+@db.inject_reader("reader", url="%DB_URL%", table="users")
+@db.inject_writer("writer", url="%DB_URL%", table="audit_log")
+def audit_user_access(reader: DbReader, writer: DbWriter) -> None:
+    user = reader.get(pk={"id": 42})
+    if user:
+        writer.insert(data={
+            "user_id": 42,
+            "user_name": user["name"],
+            "action": "profile_accessed",
+        })
+```
+
+## With HTTP Trigger
+
+Complete example with Azure Functions HTTP trigger:
+
+```python
+import azure.functions as func
+
+from azure_functions_db import DbBindings, DbReader
+
+app = func.FunctionApp()
+db = DbBindings()
+
+
+@app.function_name(name="search_users")
+@app.route(route="users/search", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+@db.inject_reader("reader", url="%DB_URL%", table="users")
+def search_users(req: func.HttpRequest, reader: DbReader) -> func.HttpResponse:
+    name = req.params.get("name", "")
+    results = reader.query(
+        "SELECT id, name, email FROM users WHERE name ILIKE :pattern",
+        params={"pattern": f"%{name}%"},
+    )
+    return func.HttpResponse(str(results), status_code=200)
+```
+
+## Configuration Reference
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `arg_name` | `str` | First positional argument. Name of the handler parameter to inject into. |
+| `url` | `str` | Database connection URL. Supports `%ENV_VAR%` substitution. |
+| `table` | `str` | Default table for operations. |
+| `engine_provider` | `EngineProvider` | Optional shared engine provider for connection pooling. |
+| `engine_kwargs` | `dict` | Additional keyword arguments passed to `create_engine()`. |
+
+## Mutual Exclusivity
+
+- `inject_writer` and `output` cannot be used on the same handler.
+- `inject_reader` and `input` can coexist but typically serve different use cases.

--- a/docs/examples/input_binding.md
+++ b/docs/examples/input_binding.md
@@ -1,0 +1,81 @@
+# Input Binding
+
+The `input` decorator injects query results directly into your handler — no
+database client needed.
+
+## Row Lookup Mode
+
+Fetch a single row by primary key:
+
+```python
+from azure_functions_db import DbBindings
+
+db = DbBindings()
+
+
+@db.input("user", url="%DB_URL%", table="users", pk={"id": 42})
+def load_user(user: dict | None) -> None:
+    if user:
+        print(user["name"])
+```
+
+### Dynamic Primary Key
+
+Resolve the primary key from handler arguments at runtime:
+
+```python
+@db.input("user", url="%DB_URL%", table="users",
+          pk=lambda req: {"id": int(req.route_params["user_id"])})
+def get_user(req, user: dict | None) -> None:
+    print(user)
+```
+
+The `pk` callable receives the same arguments as your handler.
+
+## Query Mode
+
+Fetch multiple rows with a SQL query:
+
+```python
+@db.input("users", url="%DB_URL%", query="SELECT * FROM users WHERE active = :active",
+          params={"active": True})
+def list_active_users(users: list[dict]) -> None:
+    for user in users:
+        print(user["email"])
+```
+
+## With HTTP Trigger
+
+Complete example combining Azure Functions HTTP trigger with input binding:
+
+```python
+import azure.functions as func
+
+from azure_functions_db import DbBindings
+
+app = func.FunctionApp()
+db = DbBindings()
+
+
+@app.function_name(name="get_user")
+@app.route(route="users/{user_id}", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+@db.input("user", url="%DB_URL%", table="users",
+          pk=lambda req: {"id": int(req.route_params["user_id"])})
+def get_user(req: func.HttpRequest, user: dict | None) -> func.HttpResponse:
+    if user is None:
+        return func.HttpResponse("Not found", status_code=404)
+    return func.HttpResponse(str(user), status_code=200)
+```
+
+## Configuration Reference
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `arg_name` | `str` | First positional argument. Name of the handler parameter to inject into. |
+| `url` | `str` | Database connection URL. Supports `%ENV_VAR%` substitution. |
+| `table` | `str` | Table name for row lookup mode. |
+| `pk` | `dict` or callable | Primary key for row lookup. Static dict or callable receiving handler args. |
+| `query` | `str` | SQL query for query mode. Mutually exclusive with `table`/`pk`. |
+| `params` | `dict` | Query parameters for named placeholders (`:name`). |
+| `engine_provider` | `EngineProvider` | Optional shared engine provider for connection pooling. |
+| `engine_kwargs` | `dict` | Additional keyword arguments passed to `create_engine()`. |

--- a/docs/examples/output_binding.md
+++ b/docs/examples/output_binding.md
@@ -1,0 +1,86 @@
+# Output Binding
+
+The `output` decorator injects a `DbOut` instance into your handler. Call `.set()`
+to write data to the database.
+
+## Basic Insert
+
+```python
+from azure_functions_db import DbBindings, DbOut
+
+db = DbBindings()
+
+
+@db.output("out", url="%DB_URL%", table="orders")
+def create_order(out: DbOut) -> None:
+    out.set({"id": 1, "status": "pending", "total": 99.99})
+```
+
+The write happens when `out.set()` is called. The handler's return value is
+independent of the database write.
+
+## Batch Insert
+
+Pass a list of dicts to insert multiple rows:
+
+```python
+@db.output("out", url="%DB_URL%", table="orders")
+def create_orders(out: DbOut) -> None:
+    out.set([
+        {"id": 1, "status": "pending", "total": 99.99},
+        {"id": 2, "status": "pending", "total": 49.99},
+    ])
+```
+
+## Upsert
+
+Set `action="upsert"` and specify `conflict_columns` to handle duplicates:
+
+```python
+@db.output("out", url="%DB_URL%", table="orders",
+           action="upsert", conflict_columns=["id"])
+def upsert_orders(out: DbOut) -> None:
+    out.set([
+        {"id": 1, "status": "shipped", "total": 99.99},
+        {"id": 2, "status": "pending", "total": 49.99},
+    ])
+```
+
+Supported upsert dialects: PostgreSQL, SQLite, MySQL.
+
+## With HTTP Trigger
+
+Complete example with an HTTP POST handler:
+
+```python
+import azure.functions as func
+
+from azure_functions_db import DbBindings, DbOut
+
+app = func.FunctionApp()
+db = DbBindings()
+
+
+@app.function_name(name="create_order")
+@app.route(route="orders", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
+@db.output("out", url="%DB_URL%", table="orders")
+def create_order(req: func.HttpRequest, out: DbOut) -> func.HttpResponse:
+    body = req.get_json()
+    out.set({"id": body["id"], "status": "pending", "total": body["total"]})
+    return func.HttpResponse("Created", status_code=201)
+```
+
+The return value (`HttpResponse`) is sent to the caller. The database write
+happens independently via `out.set()`.
+
+## Configuration Reference
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `arg_name` | `str` | First positional argument. Name of the handler parameter to inject `DbOut` into. |
+| `url` | `str` | Database connection URL. Supports `%ENV_VAR%` substitution. |
+| `table` | `str` | Target table name. |
+| `action` | `str` | Write action: `"insert"` (default) or `"upsert"`. |
+| `conflict_columns` | `list[str]` | Columns for upsert conflict detection. Required when `action="upsert"`. |
+| `engine_provider` | `EngineProvider` | Optional shared engine provider for connection pooling. |
+| `engine_kwargs` | `dict` | Additional keyword arguments passed to `create_engine()`. |

--- a/docs/examples/trigger.md
+++ b/docs/examples/trigger.md
@@ -1,0 +1,95 @@
+# Trigger (Change Detection)
+
+The `trigger` decorator provides poll-based change detection for relational
+databases. It detects new and changed rows by tracking a cursor column.
+
+## How It Works
+
+1. A timer trigger fires on a schedule (e.g. every minute).
+2. The trigger polls the database for rows where the cursor column is newer than the last checkpoint.
+3. Changed rows are delivered as `RowChange` events to your handler.
+4. On success, the checkpoint advances. On failure, the same batch is redelivered.
+
+!!! warning "Pseudo trigger"
+    This is not a native database trigger. It requires a real Azure Functions
+    trigger (typically a timer) to fire the polling cycle.
+
+!!! note "At-least-once delivery"
+    Duplicates may occur during crashes or lease transitions. Handlers must
+    be idempotent.
+
+## Basic Example
+
+```python
+import azure.functions as func
+from azure.storage.blob import ContainerClient
+
+from azure_functions_db import BlobCheckpointStore, DbBindings, RowChange, SqlAlchemySource
+
+app = func.FunctionApp()
+db = DbBindings()
+
+source = SqlAlchemySource(
+    url="%ORDERS_DB_URL%",
+    table="orders",
+    schema="public",
+    cursor_column="updated_at",
+    pk_columns=["id"],
+)
+
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str="%AzureWebJobsStorage%",
+        container_name="db-state",
+    ),
+    source_fingerprint=source.source_descriptor.fingerprint,
+)
+
+
+@app.function_name(name="orders_poll")
+@app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
+@db.trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+def orders_poll(timer: func.TimerRequest, events: list[RowChange]) -> None:
+    for event in events:
+        print(f"Order {event.pk}: {event.op}")
+```
+
+## RowChange Fields
+
+Each event contains:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `event_id` | `str` | Unique event identifier. |
+| `op` | `str` | Operation type (`"insert"` or `"update"`). |
+| `pk` | `dict` | Primary key values. |
+| `before` | `dict \| None` | Previous row state (if available). |
+| `after` | `dict \| None` | Current row state. |
+| `cursor` | `CursorValue` | Cursor column value for this row. |
+
+## SqlAlchemySource Configuration
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `url` | `str` | Database connection URL. Supports `%ENV_VAR%` substitution. |
+| `table` | `str` | Table to poll for changes. |
+| `schema` | `str` | Database schema (e.g. `"public"`). |
+| `cursor_column` | `str` | Column used for change tracking (must be monotonically increasing). |
+| `pk_columns` | `list[str]` | Primary key column names. |
+| `engine_provider` | `EngineProvider` | Optional shared engine provider. |
+
+## BlobCheckpointStore Configuration
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `container_client` | `ContainerClient` | Azure Blob Storage container client. |
+| `source_fingerprint` | `str` | Unique identifier for this polling source. |
+
+## Important Notes
+
+- The `cursor_column` (e.g. `updated_at`) must be reliably updated by your
+  application on every insert and update.
+- Hard deletes are not captured by cursor-based polling.
+- An empty batch (no changes) is a normal success case.
+- Use [Azurite](https://github.com/Azure/Azurite) for local development
+  checkpoint storage.

--- a/docs/examples/trigger_with_binding.md
+++ b/docs/examples/trigger_with_binding.md
@@ -1,24 +1,14 @@
-"""Trigger + Binding integration example.
+# Trigger + Output Binding
 
-Demonstrates using DbBindings decorators to detect DB changes and write
-processed results to a destination table.
+Combine the trigger and output binding to process database changes and write
+results to another table. This pattern is common for ETL pipelines, event
+processing, and data synchronization.
 
-Shows two patterns:
-    1. ``output`` — DbOut.set() explicit write (declarative)
-    2. ``inject_writer`` — client injection (imperative, for complex operations)
+## Declarative Pattern (output + DbOut)
 
-Requirements:
-    pip install azure-functions-db[postgres]
-    # or: pip install azure-functions-db[all]
+Use `@db.output()` with `DbOut.set()` for straightforward writes:
 
-Environment variables:
-    SOURCE_DB_URL: Source database connection URL
-    DEST_DB_URL: Destination database connection URL
-    AzureWebJobsStorage: Azure Storage connection string (for checkpoint)
-"""
-
-from __future__ import annotations
-
+```python
 import azure.functions as func
 from azure.storage.blob import ContainerClient
 
@@ -26,7 +16,6 @@ from azure_functions_db import (
     BlobCheckpointStore,
     DbBindings,
     DbOut,
-    DbWriter,
     EngineProvider,
     RowChange,
     SqlAlchemySource,
@@ -40,7 +29,6 @@ engine_provider = EngineProvider()
 source = SqlAlchemySource(
     url="%SOURCE_DB_URL%",
     table="orders",
-    schema="public",
     cursor_column="updated_at",
     pk_columns=["id"],
     engine_provider=engine_provider,
@@ -67,32 +55,32 @@ checkpoint_store = BlobCheckpointStore(
     engine_provider=engine_provider,
 )
 def orders_poll(timer: func.TimerRequest, events: list[RowChange], out: DbOut) -> None:
-    del timer
     out.set([
         {
             "order_id": event.pk["id"],
-            "customer_name": event.after["name"],
-            "amount": event.after["amount"],
+            "customer": event.after["name"],
             "processed_at": str(event.cursor),
         }
         for event in events
         if event.after is not None
     ])
+```
+
+## Imperative Pattern (inject_writer)
+
+Use `@db.inject_writer()` for complex write logic (transactions, conditional
+updates, multiple operations):
+
+```python
+from azure_functions_db import DbBindings, DbWriter, RowChange
+
+db = DbBindings()
 
 
-@app.function_name(name="orders_poll_imperative")
-@app.schedule(schedule="0 */5 * * * *", arg_name="timer", use_monitor=True)
 @db.trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
-@db.inject_writer(
-    "writer",
-    url="%DEST_DB_URL%",
-    table="processed_orders",
-    engine_provider=engine_provider,
-)
-def orders_poll_imperative(
-    timer: func.TimerRequest, events: list[RowChange], writer: DbWriter
-) -> None:
-    del timer
+@db.inject_writer("writer", url="%DEST_DB_URL%", table="processed_orders",
+                  engine_provider=engine_provider)
+def orders_poll_imperative(events: list[RowChange], writer: DbWriter) -> None:
     for event in events:
         if event.after is not None:
             writer.upsert(
@@ -104,3 +92,33 @@ def orders_poll_imperative(
                 },
                 conflict_columns=["order_id"],
             )
+```
+
+!!! note "Choosing between output and inject_writer"
+    Use `output` for simple, bulk writes. Use `inject_writer` when you need
+    per-row logic, conditional writes, or multiple operations per event.
+
+## Shared Connection Pooling
+
+Both examples above use `EngineProvider` to share a SQLAlchemy engine between
+the trigger source and the output destination. This avoids creating redundant
+connection pools when both source and destination use the same database server.
+
+```python
+engine_provider = EngineProvider()
+
+# Pass to both source and output/writer
+source = SqlAlchemySource(..., engine_provider=engine_provider)
+
+@db.output("out", ..., engine_provider=engine_provider)
+# or
+@db.inject_writer("writer", ..., engine_provider=engine_provider)
+```
+
+If source and destination are on different servers, you can omit `engine_provider`
+or use separate instances.
+
+## Mutual Exclusivity
+
+`output` and `inject_writer` cannot be used on the same handler. They are
+mutually exclusive decorators. Choose one pattern per function.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,93 @@
+# FAQ
+
+## General
+
+### What databases are supported?
+
+PostgreSQL, MySQL, and SQL Server via SQLAlchemy dialect drivers. Install the
+corresponding extra: `azure-functions-db[postgres]`, `azure-functions-db[mysql]`,
+or `azure-functions-db[mssql]`.
+
+### Is this an official Microsoft package?
+
+No. This is an independent community project. It is not affiliated with,
+endorsed by, or maintained by Microsoft.
+
+### What Azure Functions programming model is required?
+
+Python v2 only — the decorator-based `func.FunctionApp()` model. The legacy
+`function.json`-based v1 model is not supported.
+
+### What Python versions are supported?
+
+Python 3.11, 3.12, 3.13, and 3.14. The project metadata declares `>=3.11,<3.15`.
+
+## Trigger
+
+### Is this a real database trigger?
+
+No. It is a pseudo trigger — poll-based change detection built on top of a
+timer trigger. The package polls the database at a configurable interval and
+delivers changed rows to your handler.
+
+### What delivery guarantee does the trigger provide?
+
+At-least-once. Handlers must be idempotent. Duplicates may occur during
+crashes, lease transitions, or commit failures.
+
+### Can I use CDC instead of polling?
+
+Not currently. The package uses cursor-based polling via a monotonically
+increasing column (e.g. `updated_at`). Native CDC support is not planned.
+
+### What happens if my handler fails?
+
+The checkpoint does not advance. The same batch will be redelivered on the
+next polling cycle.
+
+### Are hard deletes detected?
+
+No. Cursor-based polling only detects inserts and updates. Use soft deletes
+(a `deleted_at` column) if you need to track deletions.
+
+## Bindings
+
+### When should I use `input` vs `inject_reader`?
+
+Use `input` for simple reads — single row lookup by primary key or a single SQL
+query. Use `inject_reader` when you need multiple queries, conditional logic,
+or full `DbReader` control within the handler.
+
+### When should I use `output` vs `inject_writer`?
+
+Use `output` for simple writes — insert or upsert via `DbOut.set()`. Use
+`inject_writer` when you need transactions, update/delete operations,
+conditional writes, or per-row logic.
+
+### Can I use input and output on the same handler?
+
+Yes. Decorator composition is supported. Place them in the correct order
+(Azure Functions decorators first, then database decorators closest to the
+function definition).
+
+### Can I use output and inject_writer on the same handler?
+
+No. They are mutually exclusive. Choose one pattern per handler.
+
+## Configuration
+
+### How does environment variable substitution work?
+
+Wrap variable names in percent signs: `url="%DB_URL%"`. The value is resolved
+from the environment at runtime. Partial substitution is also supported:
+`url="postgresql+psycopg://%DB_USER%:%DB_PASS%@%DB_HOST%/mydb"`.
+
+### Can I pass custom SQLAlchemy engine options?
+
+Yes. Use the `engine_kwargs` parameter on any decorator to pass additional
+keyword arguments to `sqlalchemy.create_engine()`.
+
+### Can I share a connection pool across decorators?
+
+Yes. Create an `EngineProvider` instance and pass it to multiple decorators or
+to `SqlAlchemySource`. Engines are created lazily and reused by URL.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,195 @@
+# Getting Started
+
+This quickstart walks you from zero to a working database-integrated Azure Functions
+app in a few minutes.
+
+By the end, you will have:
+
+- An input binding reading rows from a database
+- An output binding writing rows to a database
+- Client injection for complex operations
+
+!!! tip "Who this is for"
+    This page is for teams using the Azure Functions Python v2 programming model
+    (`func.FunctionApp()` and decorators).
+
+## Prerequisites
+
+Before starting, make sure you have:
+
+1. Python 3.11 or newer.
+2. An Azure Functions Python v2 app structure.
+3. A running database (PostgreSQL, MySQL, or SQL Server).
+4. Dependencies installed:
+    - `azure-functions`
+    - `azure-functions-db[postgres]` (or your database extra)
+
+See [Installation](installation.md) for version details.
+
+## Step 1: Install the package
+
+```bash
+pip install azure-functions-db[postgres]
+```
+
+## Step 2: Add an input binding
+
+Create or update `function_app.py` with this example:
+
+```python
+import azure.functions as func
+
+from azure_functions_db import DbBindings
+
+app = func.FunctionApp()
+db = DbBindings()
+
+
+@app.function_name(name="get_user")
+@app.route(route="users/{user_id}", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+@db.input("user", url="%DB_URL%", table="users",
+          pk=lambda req: {"id": int(req.route_params["user_id"])})
+def get_user(req: func.HttpRequest, user: dict | None) -> func.HttpResponse:
+    if user is None:
+        return func.HttpResponse("Not found", status_code=404)
+    return func.HttpResponse(str(user), status_code=200)
+```
+
+### Why this works
+
+- `@db.input("user", ...)` injects the query result into the `user` parameter.
+- `pk=lambda req: {...}` resolves the primary key dynamically from the request.
+- The handler receives a typed `dict | None` — no database client needed.
+
+!!! note "Decorator order"
+    Place `@db.input(...)` closest to the function definition,
+    below `@app.route(...)`.
+
+## Step 3: Add an output binding
+
+Add another handler that writes data:
+
+```python
+from azure_functions_db import DbBindings, DbOut
+
+app = func.FunctionApp()
+db = DbBindings()
+
+
+@app.function_name(name="create_order")
+@app.route(route="orders", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
+@db.output("out", url="%DB_URL%", table="orders")
+def create_order(req: func.HttpRequest, out: DbOut) -> func.HttpResponse:
+    body = req.get_json()
+    out.set({"id": body["id"], "status": "pending", "total": body["total"]})
+    return func.HttpResponse("Created", status_code=201)
+```
+
+### Why this works
+
+- `@db.output("out", ...)` injects a `DbOut` instance into the `out` parameter.
+- Call `out.set(data)` to write — the handler's return value is independent.
+- Pass a `dict` for single row or `list[dict]` for batch insert.
+
+## Step 4: Run your app locally
+
+Start your Azure Functions host:
+
+```bash
+func start
+```
+
+Make sure your environment has the `DB_URL` variable set:
+
+```bash
+export DB_URL="postgresql+psycopg://postgres:postgres@localhost:5432/mydb"
+```
+
+Or configure it in `local.settings.json`:
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "DB_URL": "postgresql+psycopg://postgres:postgres@localhost:5432/mydb"
+  }
+}
+```
+
+## Step 5: Test with curl
+
+Read a user:
+
+```bash
+curl -i http://localhost:7071/api/users/1
+```
+
+Expected response:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/plain
+
+{'id': 1, 'name': 'Alice', 'email': 'alice@example.com'}
+```
+
+Create an order:
+
+```bash
+curl -i -X POST http://localhost:7071/api/orders \
+  -H "Content-Type: application/json" \
+  -d '{"id": 1, "total": 99.99}'
+```
+
+Expected response:
+
+```http
+HTTP/1.1 201 Created
+
+Created
+```
+
+## Optional: Client injection for complex operations
+
+For multiple queries or transactions, use `inject_reader` / `inject_writer`:
+
+```python
+from azure_functions_db import DbBindings, DbReader, DbWriter
+
+db = DbBindings()
+
+
+@db.inject_reader("reader", url="%DB_URL%", table="users")
+@db.inject_writer("writer", url="%DB_URL%", table="audit_log")
+def complex_operation(reader: DbReader, writer: DbWriter) -> None:
+    user = reader.get(pk={"id": 42})
+    if user:
+        writer.insert(data={"user_id": 42, "action": "accessed"})
+```
+
+## Optional: Trigger for change detection
+
+Detect database changes with the poll-based trigger. See the
+[Trigger example](examples/trigger.md) for a complete walkthrough.
+
+## Troubleshooting checkpoints
+
+If something does not work as expected:
+
+1. Confirm `DB_URL` environment variable is set and the database is reachable.
+2. Confirm the database driver extra is installed (`pip show psycopg`).
+3. Confirm `@db.input(...)` or `@db.output(...)` is closest to the function definition.
+4. Confirm the table and column names match your database schema.
+5. Confirm you are using the Python v2 programming model.
+
+For deeper fixes, go to [Troubleshooting](troubleshooting.md).
+
+## Next steps
+
+- Explore [Input Binding](examples/input_binding.md) examples.
+- Explore [Output Binding](examples/output_binding.md) examples.
+- Learn about [Trigger](examples/trigger.md) for change detection.
+- Read [Client Injection](examples/client_injection.md) for advanced patterns.
+- Check [API Reference](api.md) for complete signatures.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,10 +5,11 @@ Unified DB integration (trigger + input/output binding) for Azure Functions Pyth
 ## Features
 
 - **DB Change Detection (Trigger)**: Poll-based pseudo trigger that detects new/changed rows via cursor tracking
-- **Input Binding (DbReader)**: Read rows from any SQLAlchemy-supported database
-- **Output Binding (DbWriter)**: Write, upsert, update, and delete rows
-- **SQLAlchemy-powered**: Works with PostgreSQL, MySQL, SQLite, and MSSQL
-- **Azure Functions v2 native**: Integrates with the Python v2 programming model
+- **Input Binding**: Read rows declaratively with `@db.input()` — data injected into your handler
+- **Output Binding**: Write rows declaratively with `@db.output()` and `DbOut.set()`
+- **Client Injection**: Full imperative control with `@db.inject_reader()` / `@db.inject_writer()`
+- **Multi-DB Support**: PostgreSQL, MySQL, SQL Server via SQLAlchemy
+- **Azure Functions v2 Native**: Integrates with the Python v2 programming model
 
 ## Quick Start
 
@@ -17,15 +18,15 @@ pip install azure-functions-db[postgres]
 ```
 
 ```python
-from azure_functions_db import DbBindings, PollTrigger, DbReader, DbWriter
-from azure_functions_db import DbConfig, SqlAlchemySource
+from azure_functions_db import DbBindings, DbOut, DbReader, DbWriter
+from azure_functions_db import SqlAlchemySource, BlobCheckpointStore, EngineProvider
 ```
-
-For detailed usage, see the [Python API Spec](04-python-api-spec.md).
 
 ## Documentation
 
-- [Project Overview](00-project-overview.md)
-- [Architecture](02-architecture.md)
-- [Binding Semantics](22-binding-semantics.md)
-- [API Reference](api.md)
+- [Installation](installation.md) — install and verify the package
+- [Getting Started](getting-started.md) — quickstart walkthrough
+- [Examples](examples/input_binding.md) — complete code examples
+- [API Reference](api.md) — auto-generated API docs
+- [Troubleshooting](troubleshooting.md) — common issues and solutions
+- [FAQ](faq.md) — frequently asked questions

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,124 @@
+# Installation
+
+`azure-functions-db` targets the **Azure Functions Python v2 programming model**.
+
+## Requirements
+
+- Python 3.11+
+- `azure-functions`
+- SQLAlchemy 2.0+
+
+> This package does not support the legacy `function.json`-based v1 programming model.
+
+## Version Compatibility
+
+| Component | Supported Range | Notes |
+| --- | --- | --- |
+| Python | 3.11+ | Project metadata declares `>=3.11,<3.15`. |
+| SQLAlchemy | 2.0+ | Core and ORM. |
+| `azure-functions` | Required | Use with Python v2 decorator-based `FunctionApp`. |
+
+Database driver compatibility depends on the extra you install:
+
+| Database | Extra | Driver |
+| --- | --- | --- |
+| PostgreSQL | `postgres` | [psycopg](https://www.psycopg.org/) |
+| MySQL | `mysql` | [PyMySQL](https://pymysql.readthedocs.io/) |
+| SQL Server | `mssql` | [pyodbc](https://github.com/mkleehammer/pyodbc) |
+
+## From PyPI
+
+Install with the driver extra for your database:
+
+```bash
+# Pick your database
+pip install azure-functions-db[postgres]
+pip install azure-functions-db[mysql]
+pip install azure-functions-db[mssql]
+
+# Multiple databases
+pip install azure-functions-db[postgres,mysql]
+
+# All drivers
+pip install azure-functions-db[all]
+```
+
+Your Function App dependencies should include:
+
+```text
+azure-functions
+azure-functions-db[postgres]
+```
+
+## Verify Installation
+
+Run the following command after installation:
+
+```bash
+python -c "import azure_functions_db; print(azure_functions_db.__version__)"
+```
+
+Expected outcome:
+
+- The command prints a version string such as `0.1.0`.
+- No import errors are raised.
+
+You can also verify package metadata:
+
+```bash
+pip show azure-functions-db
+```
+
+Check that your active environment is the same one used by your Function App.
+
+## Local Development
+
+```bash
+git clone https://github.com/yeongseon/azure-functions-db.git
+cd azure-functions-db
+make install
+```
+
+All project maintenance commands should go through the Makefile.
+
+## Upgrading
+
+Upgrade to the latest published version:
+
+```bash
+pip install --upgrade azure-functions-db[postgres]
+```
+
+Recommended upgrade workflow:
+
+1. Upgrade in a dedicated virtual environment.
+2. Confirm compatible `azure-functions` and SQLAlchemy versions.
+3. Run your local Azure Functions smoke tests.
+4. Confirm decorator behavior and binding contracts match expectations.
+
+For deterministic deployments, pin an explicit version in your dependency file.
+
+## Troubleshooting
+
+### ImportError: No module named `azure_functions_db`
+
+- Confirm installation ran in the correct environment.
+- Run `python -m pip install azure-functions-db[postgres]`.
+- Verify with `python -c "import azure_functions_db"`.
+
+### Driver not found (psycopg, pymysql, pyodbc)
+
+- Confirm you installed the correct extra: `pip install azure-functions-db[postgres]`.
+- Run `pip show psycopg` (or `pymysql`, `pyodbc`) to verify the driver is present.
+- SQL Server requires ODBC Driver 17+ installed at the OS level.
+
+### SQLAlchemy version mismatch
+
+- This package requires SQLAlchemy 2.0+. Check with `pip show sqlalchemy`.
+- If an older version is installed transitively, pin `sqlalchemy>=2.0` and reinstall.
+
+### Runtime dependency drift in Azure
+
+- Rebuild deployment artifacts from a clean environment.
+- Confirm `requirements.txt` includes both `azure-functions` and `azure-functions-db[postgres]`.
+- Verify the deployed Python runtime version is compatible with your lockfile.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,94 @@
+# Security
+
+Security guidelines for using `azure-functions-db` in production.
+
+## Principles
+
+- Do not embed secrets in code.
+- Use managed identity, environment variables, or a secret store.
+- Minimize checkpoint storage permissions.
+- Prefer read-only database accounts for polling.
+
+## Connection Configuration
+
+Use environment variable substitution for connection URLs:
+
+```python
+@db.input("user", url="%DB_URL%", table="users", pk={"id": 1})
+```
+
+The `%DB_URL%` placeholder is resolved from the environment at runtime.
+Never hardcode connection strings in source code.
+
+In production, consider:
+
+- **Azure Managed Identity** for passwordless database access.
+- **Azure Key Vault** references in Application Settings.
+- Keeping development and production credentials strictly separate.
+
+## Database Permissions
+
+Apply the principle of least privilege for each use case:
+
+### Polling (trigger)
+
+- `SELECT` on the target table.
+- Schema metadata read access (if required by the driver).
+
+### Read binding (input / inject_reader)
+
+- `SELECT` on the target table.
+
+### Write binding (output / inject_writer)
+
+- `INSERT`, `UPDATE`, `DELETE` as needed for the operation.
+- For upsert, the account needs both `INSERT` and `UPDATE`.
+
+### Checkpoint storage
+
+- Read and write access on the checkpoint blob container.
+- Quarantine container write access (if configured).
+
+## Data Minimization
+
+- Use the `query` parameter to project only the columns you need.
+- Exclude sensitive columns (passwords, tokens, PII) from trigger payloads.
+- The trigger delivers full row snapshots by default — restrict columns at the query level.
+
+## Logging Safety
+
+The following must never appear in log output:
+
+- Full connection strings
+- Passwords or tokens
+- Sensitive row data (PII, financial data)
+- Raw secrets
+
+`azure-functions-db` uses structured logging. Review your handler code to
+ensure sensitive data from query results is not logged inadvertently.
+
+## Multi-Tenant Considerations
+
+When handling multiple tenant databases:
+
+- Use separate poller namespaces per tenant.
+- Use separate checkpoint paths (blob prefixes or containers).
+- Use separate database credentials per tenant.
+- Never share checkpoint state across tenants.
+
+## Supply Chain Security
+
+- Pin dependencies in `requirements.txt` or a lock file.
+- Run vulnerability scanning in CI (e.g. `pip-audit`, `safety`).
+- Database drivers are installed as optional extras — only install what you need:
+    - `azure-functions-db[postgres]`
+    - `azure-functions-db[mysql]`
+    - `azure-functions-db[mssql]`
+
+## Reporting Security Issues
+
+If you discover a security vulnerability:
+
+- **Do not** open a public GitHub issue.
+- Use [GitHub Security Advisories](https://github.com/yeongseon/azure-functions-db/security/advisories) to report privately.
+- Or contact the maintainer directly.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,116 @@
+# Testing
+
+How to run and write tests for `azure-functions-db`.
+
+## Running Tests
+
+```bash
+make test        # Run all tests with pytest
+make lint        # Run Ruff linter
+make typecheck   # Run mypy type checker
+make build       # Verify package builds cleanly
+```
+
+Run all checks at once:
+
+```bash
+make check-all
+```
+
+## Coverage
+
+The project enforces a **90% coverage threshold**. Coverage is measured by
+`pytest-cov` and configured in `pyproject.toml`:
+
+```toml
+[tool.coverage.report]
+fail_under = 90
+```
+
+## Test Structure
+
+| File | Purpose |
+| --- | --- |
+| `tests/test_decorator.py` | Decorator API tests (input, output, trigger, inject_reader, inject_writer) |
+| `tests/test_public_api.py` | Export surface verification (27 symbols, version string) |
+
+## Writing Tests
+
+- Use [pytest](https://docs.pytest.org/) as the test framework.
+- Follow existing patterns in `tests/` for consistency.
+- New features must include tests that cover both success and failure cases.
+
+### Example test
+
+```python
+def test_input_decorator_injects_result():
+    db = DbBindings()
+
+    @db.input("user", url="sqlite:///:memory:", table="users", pk={"id": 1})
+    def handler(user):
+        return user
+
+    # Assert decorator configuration is correct
+    assert hasattr(handler, "__wrapped__") or callable(handler)
+```
+
+## Test Categories
+
+### Unit Tests
+
+Core logic that runs without external dependencies:
+
+- Cursor comparator and serialization
+- Event ID generation
+- SQL builder
+- Retry classifier
+- Decorator configuration and validation
+- Mutual exclusivity rules
+
+### Contract Tests
+
+Verify that all adapters satisfy the same input/output contract:
+
+- Ordering guarantees
+- Empty batch semantics
+- Checkpoint generation
+- Timezone normalization
+- Duplicate-safe cursor handling
+
+### Integration Tests
+
+Run against real database containers (Docker recommended):
+
+- PostgreSQL
+- MySQL / MariaDB
+- SQL Server
+
+### End-to-End Tests
+
+Full stack: Azure Functions local runtime + Azurite + database container.
+
+## CI Matrix
+
+The CI pipeline tests across:
+
+- **OS**: Ubuntu latest
+- **Python**: 3.11, 3.12, 3.13, 3.14
+
+Stages:
+
+1. Lint (Ruff)
+2. Type check (mypy)
+3. Unit tests
+4. Build verification
+
+## Key Test Scenarios
+
+| Scenario | Description |
+| --- | --- |
+| First run | No checkpoint exists, first batch processed successfully |
+| Identical timestamps | Multiple rows with same cursor value processed without omission |
+| Handler failure | Checkpoint does not advance |
+| Commit failure | Duplicates possible, no data loss |
+| Lease race | Two runners start simultaneously, only one commits |
+| Schema drift | Additional columns do not break existing handlers |
+| Empty tick | No changes detected, no-op succeeds |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,113 @@
+# Troubleshooting
+
+Common issues and solutions for `azure-functions-db`.
+
+## Installation Issues
+
+### ImportError: No module named `azure_functions_db`
+
+- Confirm installation ran in the correct virtual environment.
+- Run `python -m pip install azure-functions-db[postgres]`.
+- Verify with `python -c "import azure_functions_db"`.
+- Check that the active environment matches the one your Function App uses.
+
+### Driver not found (psycopg, pymysql, pyodbc)
+
+- Confirm you installed the correct database extra:
+    - PostgreSQL: `pip install azure-functions-db[postgres]`
+    - MySQL: `pip install azure-functions-db[mysql]`
+    - SQL Server: `pip install azure-functions-db[mssql]`
+- Verify the driver is installed: `pip show psycopg` (or `pymysql`, `pyodbc`).
+- SQL Server requires ODBC Driver 17+ installed at the OS level.
+
+### SQLAlchemy version mismatch
+
+- This package requires SQLAlchemy 2.0+.
+- Check your version: `pip show sqlalchemy`.
+- If an older version is installed transitively, pin `sqlalchemy>=2.0` in your requirements.
+
+## Connection Issues
+
+### Connection refused or timeout
+
+- Verify the database URL format is correct for your driver:
+    - PostgreSQL: `postgresql+psycopg://user:pass@host:5432/db`
+    - MySQL: `mysql+pymysql://user:pass@host:3306/db`
+    - SQL Server: `mssql+pyodbc://user:pass@host:1433/db?driver=ODBC+Driver+17+for+SQL+Server`
+- Confirm the database server is running and accessible from your network.
+- Check firewall rules — Azure Functions may need outbound access configured.
+
+### Environment variable not resolved
+
+- Connection URLs use `%VAR_NAME%` syntax for environment variable substitution.
+- Confirm the variable is set: `echo $DB_URL`.
+- For local development, set variables in `local.settings.json` under `Values`.
+- Partial substitution is supported: `postgresql+psycopg://%DB_USER%:%DB_PASS%@%DB_HOST%/mydb`.
+
+## Decorator Issues
+
+### TypeError: unexpected keyword argument
+
+- Check that decorator parameter names match the current API.
+- Common renames: `db_trigger` is now `trigger`, `db_input` is now `input`, `db_output` is now `output`.
+- The main class is `DbBindings` (not `DbFunctionApp`).
+
+### Multiple decorators conflict
+
+- `output` and `inject_writer` are mutually exclusive on the same handler.
+- Multiple `output` decorators on the same handler are not allowed.
+- `input` and `inject_reader` can coexist but typically serve different use cases.
+
+### Decorator order matters
+
+- Place database decorators (`@db.input(...)`, `@db.output(...)`) closest to the function definition.
+- Azure Functions decorators (`@app.route(...)`, `@app.schedule(...)`) go above.
+
+## Trigger Issues
+
+### No events received
+
+- Confirm the `cursor_column` (e.g. `updated_at`) is being updated on every row change by your application.
+- Confirm the checkpoint store (Azure Blob Storage or Azurite) is accessible.
+- Verify the timer trigger is firing: check Azure Functions logs for timer invocations.
+- On first run with no checkpoint, all existing rows matching the query will be delivered.
+
+### Duplicate events
+
+- This is expected behavior with at-least-once delivery.
+- Duplicates can occur during process crashes, lease transitions, or commit failures.
+- Handlers must be idempotent — design operations to be safely re-applied.
+
+### Hard deletes not detected
+
+- Cursor-based polling only detects inserts and updates.
+- Hard deletes (removing rows) are not captured.
+- Consider using soft deletes (a `deleted_at` column) instead.
+
+## Output Issues
+
+### DbOut.set() not writing
+
+- Confirm `.set()` is called before the handler returns.
+- Confirm the table name and column names match your database schema.
+- Check for exceptions in the Azure Functions log output.
+
+### Wrong table or columns
+
+- The `table` parameter must match the actual database table name.
+- Column names in the dict passed to `.set()` must match table columns exactly.
+
+## Azure Deployment Issues
+
+### Works locally but fails in Azure
+
+- Confirm `requirements.txt` includes the driver extra: `azure-functions-db[postgres]`.
+- Confirm environment variables are set in Azure Portal > Function App > Configuration.
+- Verify the deployed Python runtime version matches your local version.
+- Rebuild deployment artifacts from a clean environment to avoid stale dependencies.
+
+### Checkpoint storage not accessible
+
+- Confirm `AzureWebJobsStorage` is configured in Application Settings.
+- Confirm the blob container exists or the app has permission to create it.
+- For local development, use Azurite: `AzureWebJobsStorage=UseDevelopmentStorage=true`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,37 +14,33 @@ theme:
 nav:
   - Home: index.md
   - Getting Started:
-      - Project Overview: 00-project-overview.md
-      - PRD: 01-PRD.md
-      - Architecture: 02-architecture.md
-      - Semantics: 03-semantics.md
+      - Installation: installation.md
+      - Quickstart: getting-started.md
   - User Guide:
-      - Python API Spec: 04-python-api-spec.md
-      - Adapter SDK: 05-adapter-sdk.md
-      - Checkpoint & Lease: 06-checkpoint-lease-spec.md
-      - Event Model: 07-event-model.md
+      - Architecture: 02-architecture.md
       - Binding Semantics: 22-binding-semantics.md
-  - Development:
-      - Repository Structure: 08-repo-structure.md
-      - Local Dev Guide: 09-local-dev-guide.md
-      - Test Strategy: 10-test-strategy.md
-      - Observability: 11-observability.md
-      - Security: 12-security.md
-      - Deployment Guide: 13-deployment-guide.md
-      - Dev Checklist: 21-dev-checklist.md
-      - Contributing: 15-CONTRIBUTING.md
+      - Python API Spec: 04-python-api-spec.md
+      - Local Development: 09-local-dev-guide.md
+  - Examples:
+      - Input Binding: examples/input_binding.md
+      - Output Binding: examples/output_binding.md
+      - Trigger: examples/trigger.md
+      - Trigger + Binding: examples/trigger_with_binding.md
+      - Client Injection: examples/client_injection.md
+  - API Reference: api.md
+  - Contributing:
+      - Guidelines: contributing.md
+      - Testing: testing.md
+  - Troubleshooting: troubleshooting.md
+  - FAQ: faq.md
+  - Security: security.md
   - Architecture Decision Records:
       - ADR-001 Pseudo Trigger: 16-ADR-001-pseudo-trigger-over-native.md
       - ADR-002 SQLAlchemy Adapter: 17-ADR-002-sqlalchemy-centric-adapter.md
       - ADR-003 Blob Checkpoint MVP: 18-ADR-003-blob-checkpoint-mvp.md
       - ADR-004 At-Least-Once Default: 19-ADR-004-at-least-once-default.md
       - ADR-005 Unified Package: 23-ADR-005-unified-package-design.md
-  - Reference:
-      - Roadmap: 14-roadmap.md
-      - Open Issues: 20-open-issues.md
-      - References: 99-references.md
-      - Release Process: release_process.md
-  - API Reference: api.md
+  - Changelog: changelog.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary

- Add 13 new user-facing documentation pages matching the azure-functions-validation pattern
- Restructure `mkdocs.yml` nav to match sibling repos (Home > Getting Started > User Guide > Examples > API Reference > Contributing > Troubleshooting > FAQ > Security > ADRs > Changelog)
- Fix stale `trigger_with_binding` example to use new DbOut API

## New Documentation Pages

### Getting Started
- `docs/installation.md` — Requirements, version compatibility, PyPI install, verify, troubleshooting
- `docs/getting-started.md` — Quickstart walkthrough with input/output bindings, curl tests, expected responses

### Examples (5 pages)
- `docs/examples/input_binding.md` — Row lookup, query mode, HTTP trigger integration
- `docs/examples/output_binding.md` — Insert, batch, upsert, HTTP trigger integration
- `docs/examples/trigger.md` — Poll-based change detection, SqlAlchemySource, BlobCheckpointStore
- `docs/examples/trigger_with_binding.md` — Trigger + output (DbOut) and trigger + inject_writer patterns
- `docs/examples/client_injection.md` — inject_reader/inject_writer for complex operations

### Reference
- `docs/changelog.md` — Versioning scheme, full version history including unreleased post-0.1.0 changes
- `docs/troubleshooting.md` — Installation, connection, decorator, trigger, output, deployment issues
- `docs/faq.md` — General, trigger, bindings, configuration FAQs

### Contributing
- `docs/contributing.md` — Development setup, branch naming, PR guidelines, code style, test requirements
- `docs/testing.md` — Running tests, coverage threshold, test categories, CI matrix
- `docs/security.md` — Connection config, DB permissions, data minimization, logging safety, supply chain

## Other Changes
- Restructured `mkdocs.yml` nav from design-oriented to user-oriented structure
- Updated `docs/index.md` to link new documentation pages
- Fixed `examples/trigger_with_binding/function_app.py` to use `DbOut` + `.set()` pattern (was using deprecated return-value auto-write)

## Verification
- All 482 tests passing
- 93.78% coverage (threshold: 90%)
- Lint clean (ruff + mypy)