### PR TITLE
fix: resolve mypy errors in e2e and integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ dev = [
     "pytest-cov",
     "pytest-html",
     "ruff==0.15.10",
+    "requests",
+    "types-requests",
 ]
 docs = [
     "mkdocs<2.0",

--- a/tests/e2e/azure/test_azure_smoke.py
+++ b/tests/e2e/azure/test_azure_smoke.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import time
+from typing import Any
 
 import pytest
 import requests
@@ -21,12 +22,12 @@ SKIP_REASON = "E2E_BASE_URL not set — skipping Azure e2e tests"
 pytestmark = pytest.mark.azure_e2e
 
 
-def _get(path: str, **kwargs: object) -> requests.Response:
-    return requests.get(f"{BASE_URL}{path}", timeout=30, **kwargs)  # type: ignore[arg-type]
+def _get(path: str, **kwargs: Any) -> requests.Response:
+    return requests.get(f"{BASE_URL}{path}", timeout=30, **kwargs)
 
 
-def _post(path: str, **kwargs: object) -> requests.Response:
-    return requests.post(f"{BASE_URL}{path}", timeout=30, **kwargs)  # type: ignore[arg-type]
+def _post(path: str, **kwargs: Any) -> requests.Response:
+    return requests.post(f"{BASE_URL}{path}", timeout=30, **kwargs)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/e2e/host/conftest.py
+++ b/tests/e2e/host/conftest.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 import time
+from typing import Any
 
 import pytest
 import requests
@@ -16,12 +17,12 @@ BASE_URL = os.environ.get("E2E_BASE_URL", "").rstrip("/")
 SKIP_REASON = "E2E_BASE_URL not set — skipping host e2e tests"
 
 
-def _get(path: str, **kwargs: object) -> requests.Response:
-    return requests.get(f"{BASE_URL}{path}", timeout=30, **kwargs)  # type: ignore[arg-type]
+def _get(path: str, **kwargs: Any) -> requests.Response:
+    return requests.get(f"{BASE_URL}{path}", timeout=30, **kwargs)
 
 
-def _post(path: str, **kwargs: object) -> requests.Response:
-    return requests.post(f"{BASE_URL}{path}", timeout=30, **kwargs)  # type: ignore[arg-type]
+def _post(path: str, **kwargs: Any) -> requests.Response:
+    return requests.post(f"{BASE_URL}{path}", timeout=30, **kwargs)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/integration/db/test_writer_live.py
+++ b/tests/integration/db/test_writer_live.py
@@ -51,7 +51,7 @@ def _read_all(engine: Engine, table_name: str) -> list[dict[str, object]]:
 
 
 def _rows_by_id(engine: Engine) -> dict[int, dict[str, object]]:
-    return {int(row["id"]): row for row in _read_all(engine, "users")}
+    return {int(str(row["id"])): row for row in _read_all(engine, "users")}
 
 
 @pytest.fixture(params=_WRITER_DBS)


### PR DESCRIPTION
## Summary
- Add `types-requests` and `requests` to dev dependencies
- Change `**kwargs: object` to `**kwargs: Any` in e2e test helpers
- Remove stale `# type: ignore[arg-type]` comments
- Fix `int(row["id"])` overload mismatch in integration test

Closes #72