### PR TITLE
docs: clarify that any SQLAlchemy-compatible database works

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,54 @@ Azure Functions Python v2 has no built-in database integration story:
 - **Data injection** — `input` injects query results directly; `output` auto-writes return values
 - **Client injection** — `inject_reader`/`inject_writer` for imperative control when needed
 
+## Choose your integration path
+
+| Path | When to use | What to do |
+|------|-------------|------------|
+| **Built-in extras** | PostgreSQL, MySQL, or SQL Server | `pip install azure-functions-db[postgres]` and go |
+| **Bring your own SQLAlchemy database** | Oracle, CockroachDB, DuckDB, or any other RDBMS with a SQLAlchemy dialect | Install the driver, use the SQLAlchemy connection URL |
+| **Custom trigger source** | Non-SQL sources (MongoDB, Kafka, REST APIs) | Implement the `SourceAdapter` Protocol |
+
+### Bring your own database
+
+The bindings and `SqlAlchemySource` work with **any database that has a SQLAlchemy dialect**. The built-in extras just bundle common drivers for convenience.
+
+Three steps:
+
+1. **Install the driver** — e.g. `pip install oracledb` for Oracle
+2. **Use the SQLAlchemy URL** — e.g. `url="oracle+oracledb://user:pass@host/db"`
+3. **Pass engine options if needed** — use `engine_kwargs` for driver-specific settings
+
+```python
+from azure_functions_db import DbBindings
+
+db = DbBindings()
+
+@db.input("rows", url="oracle+oracledb://user:pass@host:1521/mydb",
+          query="SELECT * FROM orders WHERE status = :status",
+          params={"status": "pending"})
+def read_oracle_orders(rows: list[dict]) -> None:
+    for row in rows:
+        print(row)
+```
+
+The same applies to triggers — `SqlAlchemySource` accepts any SQLAlchemy URL:
+
+```python
+source = SqlAlchemySource(
+    url="oracle+oracledb://user:pass@host:1521/mydb",
+    table="orders",
+    cursor_column="updated_at",
+    pk_columns=["id"],
+)
+```
+
+> **Note:** Only the built-in extras (PostgreSQL, MySQL, SQL Server) are tested in CI. Other dialects work through SQLAlchemy compatibility but are not explicitly tested by this project.
+
+### Custom trigger source
+
+If your data source has no SQLAlchemy dialect, implement the [`SourceAdapter`](docs/05-adapter-sdk.md) protocol and pass it directly to `db.trigger(source=...)`. See the [Adapter SDK](docs/05-adapter-sdk.md) for the full contract.
+
 ## Shared Core
 
 `azure-functions-db` now exposes shared infrastructure for upcoming bindings. Use `DbConfig` for normalized connection settings and `EngineProvider` when multiple components should reuse the same lazily created SQLAlchemy engine.
@@ -271,13 +319,17 @@ def orders_poll(timer: func.TimerRequest, events: list[RowChange], out: DbOut) -
 
 See [`examples/trigger_with_binding/`](examples/trigger_with_binding/) for a complete runnable sample.
 
-## Supported Databases
+## Built-in Extras
+
+These databases have pre-packaged driver dependencies. Install the matching extra and you're ready to go.
 
 | Database | Extra | Driver |
 |----------|-------|--------|
 | PostgreSQL | `azure-functions-db[postgres]` | [psycopg](https://www.psycopg.org/) |
 | MySQL | `azure-functions-db[mysql]` | [PyMySQL](https://pymysql.readthedocs.io/) |
 | SQL Server | `azure-functions-db[mssql]` | [pyodbc](https://github.com/mkleehammer/pyodbc) |
+
+Any other database with a [SQLAlchemy dialect](https://docs.sqlalchemy.org/en/20/dialects/) works too — just install the driver yourself. See [Choose your integration path](#choose-your-integration-path).
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-db/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Database integration for **Azure Functions Python v2** — poll-based change detection trigger and input/output bindings using SQLAlchemy.
+Database integration for **Azure Functions Python v2** — trigger, input/output bindings, and change detection for **any database with a SQLAlchemy dialect**.
 
 ---
 
@@ -28,7 +28,7 @@ Azure Functions Python v2 has no built-in database integration story:
 ## What it does
 
 - **Pseudo DB trigger** — poll-based change detection with checkpoint, lease, and at-least-once delivery
-- **Multi-DB support** — PostgreSQL, MySQL, and SQL Server via SQLAlchemy dialects
+- **Any SQLAlchemy database** — PostgreSQL, MySQL, SQL Server out of the box; Oracle, CockroachDB, DuckDB, and [any other dialect](https://docs.sqlalchemy.org/en/20/dialects/) with one extra `pip install`
 - **Single `pip install`** — one package with optional extras for each database driver
 - **Data injection** — `input` injects query results directly; `output` auto-writes return values
 - **Client injection** — `inject_reader`/`inject_writer` for imperative control when needed
@@ -39,11 +39,11 @@ Azure Functions Python v2 has no built-in database integration story:
 |------|-------------|------------|
 | **Built-in extras** | PostgreSQL, MySQL, or SQL Server | `pip install azure-functions-db[postgres]` and go |
 | **Bring your own SQLAlchemy database** | Oracle, CockroachDB, DuckDB, or any other RDBMS with a SQLAlchemy dialect | Install the driver, use the SQLAlchemy connection URL |
-| **Custom trigger source** | Non-SQL sources (MongoDB, Kafka, REST APIs) | Implement the `SourceAdapter` Protocol |
+| **Custom trigger source** *(triggers only)* | Non-SQL sources (MongoDB, Kafka, REST APIs) | Implement the `SourceAdapter` Protocol for `db.trigger()` |
 
 ### Bring your own database
 
-The bindings and `SqlAlchemySource` work with **any database that has a SQLAlchemy dialect**. The built-in extras just bundle common drivers for convenience.
+The bindings and `SqlAlchemySource` are designed to work with **any database that has a SQLAlchemy dialect**. The built-in extras just bundle common drivers for convenience.
 
 Three steps:
 
@@ -67,6 +67,8 @@ def read_oracle_orders(rows: list[dict]) -> None:
 The same applies to triggers — `SqlAlchemySource` accepts any SQLAlchemy URL:
 
 ```python
+from azure_functions_db import SqlAlchemySource
+
 source = SqlAlchemySource(
     url="oracle+oracledb://user:pass@host:1521/mydb",
     table="orders",
@@ -75,11 +77,11 @@ source = SqlAlchemySource(
 )
 ```
 
-> **Note:** Only the built-in extras (PostgreSQL, MySQL, SQL Server) are tested in CI. Other dialects work through SQLAlchemy compatibility but are not explicitly tested by this project.
+> **Note:** The built-in extras (PostgreSQL, MySQL, SQL Server) are the tested path. Other dialects work through SQLAlchemy compatibility but are not explicitly tested by this project. Exact connection URL syntax varies by driver — check your driver's documentation.
 
 ### Custom trigger source
 
-If your data source has no SQLAlchemy dialect, implement the [`SourceAdapter`](docs/05-adapter-sdk.md) protocol and pass it directly to `db.trigger(source=...)`. See the [Adapter SDK](docs/05-adapter-sdk.md) for the full contract.
+If your data source has no SQLAlchemy dialect, implement the [`SourceAdapter`](docs/05-adapter-sdk.md) protocol and pass it directly to `db.trigger(source=...)`. This applies only to the trigger feature. See the [Adapter SDK](docs/05-adapter-sdk.md) for the full contract.
 
 ## Shared Core
 

--- a/docs/05-adapter-sdk.md
+++ b/docs/05-adapter-sdk.md
@@ -1,5 +1,7 @@
 # Adapter SDK
 
+> **Most users don't need this document.** If your database has a SQLAlchemy dialect, just install the driver and use the connection URL — bindings and `SqlAlchemySource` will work out of the box. This document is for developers building adapters for databases that cannot be reached through SQLAlchemy.
+
 This document defines the internal and external extension contract for developers adding DB adapters.
 
 ## 1. Purpose

--- a/docs/05-adapter-sdk.md
+++ b/docs/05-adapter-sdk.md
@@ -1,6 +1,6 @@
 # Adapter SDK
 
-> **Most users don't need this document.** If your database has a SQLAlchemy dialect, just install the driver and use the connection URL — bindings and `SqlAlchemySource` will work out of the box. This document is for developers building adapters for databases that cannot be reached through SQLAlchemy.
+> **Most users don't need this document.** If your database has a SQLAlchemy dialect, just install the driver and use the connection URL — bindings and `SqlAlchemySource` usually do not require a custom adapter. This document is for developers building adapters for databases that cannot be reached through SQLAlchemy.
 
 This document defines the internal and external extension contract for developers adding DB adapters.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,18 +8,18 @@
 corresponding extra: `azure-functions-db[postgres]`, `azure-functions-db[mysql]`,
 or `azure-functions-db[mssql]`.
 
-**Any SQLAlchemy dialect**: The bindings and `SqlAlchemySource` work with any
-database that has a SQLAlchemy driver — Oracle, CockroachDB, SQLite, DuckDB, etc.
+**Any SQLAlchemy dialect**: The bindings and `SqlAlchemySource` are designed to work with
+any database that has a SQLAlchemy driver — Oracle, CockroachDB, SQLite, DuckDB, etc.
 Install the driver (`pip install oracledb`), use the SQLAlchemy connection URL,
-and you're set. Only the built-in extras are tested in CI; other dialects work
-through SQLAlchemy compatibility.
+and you're set. The built-in extras are the tested path; other dialects work
+through SQLAlchemy compatibility. Exact connection URL syntax varies by driver.
 
 ### How do I use my own database?
 
 Three steps:
 
 1. **Install the driver** — for example `pip install oracledb` for Oracle
-2. **Use the SQLAlchemy connection URL** — `url="oracle+oracledb://user:pass@host/db"`
+2. **Use the SQLAlchemy connection URL** — e.g. `url="oracle+oracledb://user:pass@host/db"` (exact format varies by driver)
 3. **Pass engine options if needed** — use `engine_kwargs` for driver-specific settings
 
 This works for bindings (`input`, `output`, `inject_reader`, `inject_writer`)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,9 +4,30 @@
 
 ### What databases are supported?
 
-PostgreSQL, MySQL, and SQL Server via SQLAlchemy dialect drivers. Install the
+**Built-in extras** (driver included): PostgreSQL, MySQL, and SQL Server. Install the
 corresponding extra: `azure-functions-db[postgres]`, `azure-functions-db[mysql]`,
 or `azure-functions-db[mssql]`.
+
+**Any SQLAlchemy dialect**: The bindings and `SqlAlchemySource` work with any
+database that has a SQLAlchemy driver — Oracle, CockroachDB, SQLite, DuckDB, etc.
+Install the driver (`pip install oracledb`), use the SQLAlchemy connection URL,
+and you're set. Only the built-in extras are tested in CI; other dialects work
+through SQLAlchemy compatibility.
+
+### How do I use my own database?
+
+Three steps:
+
+1. **Install the driver** — for example `pip install oracledb` for Oracle
+2. **Use the SQLAlchemy connection URL** — `url="oracle+oracledb://user:pass@host/db"`
+3. **Pass engine options if needed** — use `engine_kwargs` for driver-specific settings
+
+This works for bindings (`input`, `output`, `inject_reader`, `inject_writer`)
+and for `SqlAlchemySource`-based triggers.
+
+If your data source does not have a SQLAlchemy dialect (e.g. MongoDB, Kafka),
+implement the `SourceAdapter` protocol and pass it to `db.trigger(source=...)`.
+See [Adapter SDK](05-adapter-sdk.md) for details.
 
 ### Is this an official Microsoft package?
 


### PR DESCRIPTION
## Summary

- Add **"Choose your integration path"** section to README with 3-level guide: built-in extras → bring-your-own SQLAlchemy DB → custom SourceAdapter
- Rename "Supported Databases" to **"Built-in Extras"** with note that any SQLAlchemy dialect works
- Add Oracle DB code example showing BYOD pattern (bindings + trigger)
- Update **FAQ**: expanded "What databases are supported?" + new "How do I use my own database?"
- Add clarifying note at top of **Adapter SDK** doc: most users don't need it

## Motivation

Users reading the README/FAQ currently think the package only supports PostgreSQL, MySQL, and SQL Server. In reality, any SQLAlchemy-compatible database works — the built-in extras just bundle drivers for convenience.

## Files Changed

| File | Change |
|------|--------|
| `README.md` | New "Choose your integration path" section; "Supported Databases" → "Built-in Extras" |
| `docs/faq.md` | Rewritten DB support FAQ + new BYOD FAQ |
| `docs/05-adapter-sdk.md` | Top-level clarifying note |

Closes #74