### PR TITLE
docs: add BYOD example apps (Oracle DB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ source = SqlAlchemySource(
 
 > **Note:** The built-in extras (PostgreSQL, MySQL, SQL Server) are the tested path. Other dialects work through SQLAlchemy compatibility but are not explicitly tested by this project. Exact connection URL syntax varies by driver — check your driver's documentation.
 
+> See [`examples/byod_oracle/`](examples/byod_oracle/) for a complete runnable Function App and [`examples/usage_byod.py`](examples/usage_byod.py) for a minimal standalone script.
+
 ### Custom trigger source
 
 If your data source has no SQLAlchemy dialect, implement the [`SourceAdapter`](docs/05-adapter-sdk.md) protocol and pass it directly to `db.trigger(source=...)`. This applies only to the trigger feature. See the [Adapter SDK](docs/05-adapter-sdk.md) for the full contract.

--- a/examples/byod_oracle/function_app.py
+++ b/examples/byod_oracle/function_app.py
@@ -1,0 +1,101 @@
+"""Example: Bring Your Own Database — Oracle DB with azure-functions-db.
+
+Demonstrates that azure-functions-db works with any SQLAlchemy dialect,
+not just the built-in extras (PostgreSQL, MySQL, SQL Server).
+
+This example uses Oracle via the ``oracledb`` driver. The same pattern
+applies to CockroachDB, DuckDB, or any other database that has a
+SQLAlchemy dialect — just swap the driver and connection URL.
+
+Prerequisites:
+    pip install azure-functions-db oracledb
+
+Environment variables:
+    ORACLE_DB_URL: Oracle connection string
+        e.g. oracle+oracledb://user:pass@host:1521/?service_name=XEPDB1
+    AzureWebJobsStorage: Azure Storage connection string (for checkpoint)
+
+Note:
+    Oracle is used here as a representative BYOD example.
+    The exact connection URL format varies by driver — check your
+    driver's documentation for the correct syntax.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import azure.functions as func
+from azure.storage.blob import ContainerClient
+
+from azure_functions_db import (
+    BlobCheckpointStore,
+    DbBindings,
+    DbOut,
+    RowChange,
+    SqlAlchemySource,
+)
+
+app = func.FunctionApp()
+db = DbBindings()
+logger = logging.getLogger(__name__)
+
+# --- Trigger: poll Oracle table for changes ---
+
+source = SqlAlchemySource(
+    url="%ORACLE_DB_URL%",
+    table="orders",
+    cursor_column="updated_at",
+    pk_columns=["id"],
+)
+
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str="%AzureWebJobsStorage%",
+        container_name="db-state",
+    ),
+    source_fingerprint=source.source_descriptor.fingerprint,
+)
+
+
+@app.function_name(name="oracle_orders_poll")
+@app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
+@db.trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+def oracle_orders_poll(timer: func.TimerRequest, events: list[RowChange]) -> None:
+    del timer
+    logger.info("Processed %d order events from Oracle", len(events))
+    for event in events:
+        logger.info("Order %s: %s -> %s", event.pk, event.op, event.after)
+
+
+# --- Input binding: read from Oracle ---
+
+
+@app.function_name(name="oracle_get_orders")
+@app.route(route="orders", methods=["GET"])
+@db.input(
+    "orders",
+    url="%ORACLE_DB_URL%",
+    query="SELECT * FROM orders WHERE status = :status",
+    params={"status": "pending"},
+)
+def oracle_get_orders(
+    req: func.HttpRequest, orders: list[dict]
+) -> func.HttpResponse:
+    del req
+    return func.HttpResponse(
+        f"Found {len(orders)} pending orders",
+        status_code=200,
+    )
+
+
+# --- Output binding: write to Oracle ---
+
+
+@app.function_name(name="oracle_create_order")
+@app.route(route="orders", methods=["POST"])
+@db.output("out", url="%ORACLE_DB_URL%", table="orders")
+def oracle_create_order(req: func.HttpRequest, out: DbOut) -> func.HttpResponse:
+    body = req.get_json()
+    out.set(body)
+    return func.HttpResponse("Created", status_code=201)

--- a/examples/byod_oracle/local.settings.sample.json
+++ b/examples/byod_oracle/local.settings.sample.json
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "ORACLE_DB_URL": "oracle+oracledb://user:pass@localhost:1521/?service_name=XEPDB1"
+  }
+}

--- a/examples/byod_oracle/requirements.txt
+++ b/examples/byod_oracle/requirements.txt
@@ -1,0 +1,4 @@
+azure-functions>=1.22.0
+azure-functions-db
+oracledb>=2.0
+azure-storage-blob>=12.21.0

--- a/examples/usage_byod.py
+++ b/examples/usage_byod.py
@@ -1,0 +1,54 @@
+"""Minimal BYOD (Bring Your Own Database) example.
+
+Shows the simplest possible usage of azure-functions-db with a
+non-built-in database. This example uses Oracle, but the same pattern
+works with any SQLAlchemy dialect:
+
+    CockroachDB:  cockroachdb://user:pass@host:26257/db
+    DuckDB:       duckdb:///path/to/local.db
+    SQLite:       sqlite:///path/to/local.db
+    Firebird:     firebird+fdb://user:pass@host/db
+
+Prerequisites:
+    pip install azure-functions-db oracledb
+
+Usage:
+    ORACLE_DB_URL="oracle+oracledb://user:pass@host:1521/?service_name=XEPDB1"
+    python examples/usage_byod.py
+"""
+
+from __future__ import annotations
+
+import os
+
+from azure_functions_db import DbBindings, DbReader
+
+db = DbBindings()
+
+# The only thing that changes for BYOD is the URL and the driver install.
+# Everything else — decorators, DbReader, DbWriter, SqlAlchemySource — is identical.
+
+url = os.environ.get(
+    "ORACLE_DB_URL",
+    "oracle+oracledb://demo:demo@localhost:1521/?service_name=XEPDB1",
+)
+
+
+@db.inject_reader("reader", url=url, table="orders")
+def read_orders(reader: DbReader) -> None:
+    # Single row lookup
+    order = reader.get(pk={"id": 1})
+    print("Single order:", order)
+
+    # Query
+    rows = reader.query(
+        "SELECT * FROM orders WHERE status = :status",
+        params={"status": "pending"},
+    )
+    print(f"Pending orders: {len(rows)}")
+    for row in rows:
+        print(f"  #{row['id']}: {row['status']}")
+
+
+if __name__ == "__main__":
+    read_orders()

--- a/examples/usage_byod.py
+++ b/examples/usage_byod.py
@@ -10,7 +10,8 @@ works with any SQLAlchemy dialect:
     Firebird:     firebird+fdb://user:pass@host/db
 
 Prerequisites:
-    pip install azure-functions-db oracledb
+    pip install azure-functions-db <your-driver>
+    # e.g. pip install azure-functions-db oracledb
 
 Usage:
     ORACLE_DB_URL="oracle+oracledb://user:pass@host:1521/?service_name=XEPDB1"
@@ -28,10 +29,12 @@ db = DbBindings()
 # The only thing that changes for BYOD is the URL and the driver install.
 # Everything else — decorators, DbReader, DbWriter, SqlAlchemySource — is identical.
 
-url = os.environ.get(
-    "ORACLE_DB_URL",
-    "oracle+oracledb://demo:demo@localhost:1521/?service_name=XEPDB1",
-)
+url = os.environ.get("ORACLE_DB_URL")
+if not url:
+    raise SystemExit(
+        "Set ORACLE_DB_URL environment variable, e.g.:\n"
+        '  export ORACLE_DB_URL="oracle+oracledb://user:pass@host:1521/?service_name=XEPDB1"'
+    )
 
 
 @db.inject_reader("reader", url=url, table="orders")


### PR DESCRIPTION
## Summary

- Add `examples/byod_oracle/function_app.py` — complete Azure Function App showing trigger + input + output bindings with Oracle DB via `oracledb` driver
- Add `examples/usage_byod.py` — minimal standalone script with `inject_reader` showing BYOD pattern
- Update README BYOD section to link both examples

## Why

PR #75 added "Bring Your Own Database" documentation, but had no runnable example code. Without actual examples in `examples/`, the BYOD story isn't credible — existing examples are all PostgreSQL.

## New Files

| File | What it shows |
|------|---------------|
| `examples/byod_oracle/function_app.py` | Full Function App: trigger (poll Oracle table), input binding (HTTP GET → query), output binding (HTTP POST → insert) |
| `examples/usage_byod.py` | Minimal script: `inject_reader` with Oracle URL, lists other dialect URL formats in docstring |

Both follow the existing example conventions (`poll_orders/`, `usage_postgres.py`).

Relates to #74