### PR TITLE
fix: declare wheel packages explicitly for hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ build-backend = "hatchling.build"
 sources = ["src"]
 
 [tool.hatch.build.targets.wheel]
+packages = ["src/azure_functions_db"]
 
 [tool.hatch.version]
 path = "src/azure_functions_db/__init__.py"


### PR DESCRIPTION
## Summary

Restore the ability to `pip install -e .`, `make install`, and `hatch run test` on a fresh checkout. The hatchling wheel target was relying on auto-detection that no longer works because the distribution name does not match the import package directory.

## Repro

```bash
git clean -fdx
pip install -e .
```

Fails at metadata generation:

```
ValueError: Unable to determine which files to ship inside the wheel
using the following heuristics: ...

The most likely cause of this is that there is no directory that matches
the name of your project (azure_functions_db_python).
```

## Root Cause

`pyproject.toml`:

```toml
[project]
name = "azure-functions-db-python"   # normalized: azure_functions_db_python
...
[tool.hatch.build.targets.wheel]            # empty -> hatchling auto-detect
```

Hatchling's wheel builder looks for a top-level package directory matching the normalized project name (`azure_functions_db_python`). The actual package directory is `src/azure_functions_db/` (different layout), so detection fails.

## Fix

Declare the wheel target explicitly:

```toml
[tool.hatch.build.targets.wheel]
packages = ["src/azure_functions_db"]
```

This is the standard minimal hatchling configuration when the distribution name and import package name differ. It does not change the import path, the sdist contents, or any runtime behavior.

## Verification

Locally:

```
$ pip install --no-deps --dry-run -e .
Preparing editable metadata (pyproject.toml): finished with status 'done'
Would install azure-functions-db-python-...
```

`ci-test.yml` on `main` has been failing on every push for this exact reason. CI on this PR will confirm the fix.

## Notes

- 1-line change to `pyproject.toml`.
- No template, doc, or runtime change.
- Same pattern as fixed by yeongseon/azure-functions-scaffold-python#70.