### PR TITLE
fix: align distribution name with PyPI publish name (azure-functions-db)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Azure Functions DB
 
-[![PyPI](https://img.shields.io/pypi/v/azure-functions-db-python.svg)](https://pypi.org/project/azure-functions-db-python/)
-[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-db-python/)
+[![PyPI](https://img.shields.io/pypi/v/azure-functions-db.svg)](https://pypi.org/project/azure-functions-db/)
+[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-db/)
 [![CI](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-db-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-db-python)
@@ -37,7 +37,7 @@ Azure Functions Python v2 has no built-in database integration story:
 
 | Path | When to use | What to do |
 |------|-------------|------------|
-| **Built-in extras** | PostgreSQL, MySQL, or SQL Server | `pip install azure-functions-db-python[postgres]` and go |
+| **Built-in extras** | PostgreSQL, MySQL, or SQL Server | `pip install azure-functions-db[postgres]` and go |
 | **Bring your own SQLAlchemy database** | Oracle, CockroachDB, DuckDB, or any other RDBMS with a SQLAlchemy dialect | Install the driver, use the SQLAlchemy connection URL |
 | **Custom trigger source** *(triggers only)* | Non-SQL sources (MongoDB, Kafka, REST APIs) | Implement the `SourceAdapter` Protocol for `db.trigger()` |
 
@@ -93,22 +93,22 @@ If your data source has no SQLAlchemy dialect, implement the [`SourceAdapter`](d
 
 ```bash
 # Core package (pick your database)
-pip install azure-functions-db-python[postgres]
-pip install azure-functions-db-python[mysql]
-pip install azure-functions-db-python[mssql]
+pip install azure-functions-db[postgres]
+pip install azure-functions-db[mysql]
+pip install azure-functions-db[mssql]
 
 # Multiple databases
-pip install azure-functions-db-python[postgres,mysql]
+pip install azure-functions-db[postgres,mysql]
 
 # All drivers
-pip install azure-functions-db-python[all]
+pip install azure-functions-db[all]
 ```
 
 Your Function App dependencies should include:
 
 ```text
 azure-functions
-azure-functions-db-python[postgres]
+azure-functions-db[postgres]
 ```
 
 ## Quick Start
@@ -329,9 +329,9 @@ These databases have pre-packaged driver dependencies. Install the matching extr
 
 | Database | Extra | Driver |
 |----------|-------|--------|
-| PostgreSQL | `azure-functions-db-python[postgres]` | [psycopg](https://www.psycopg.org/) |
-| MySQL | `azure-functions-db-python[mysql]` | [PyMySQL](https://pymysql.readthedocs.io/) |
-| SQL Server | `azure-functions-db-python[mssql]` | [pyodbc](https://github.com/mkleehammer/pyodbc) |
+| PostgreSQL | `azure-functions-db[postgres]` | [psycopg](https://www.psycopg.org/) |
+| MySQL | `azure-functions-db[mysql]` | [PyMySQL](https://pymysql.readthedocs.io/) |
+| SQL Server | `azure-functions-db[mssql]` | [pyodbc](https://github.com/mkleehammer/pyodbc) |
 
 Any other database with a [SQLAlchemy dialect](https://docs.sqlalchemy.org/en/20/dialects/) works too — just install the driver yourself. See [Choose your integration path](#choose-your-integration-path).
 

--- a/examples/byod_oracle/requirements.txt
+++ b/examples/byod_oracle/requirements.txt
@@ -1,4 +1,4 @@
 azure-functions>=1.22.0
-azure-functions-db-python
+azure-functions-db
 oracledb>=2.0
 azure-storage-blob>=12.21.0

--- a/examples/e2e_app/requirements.txt
+++ b/examples/e2e_app/requirements.txt
@@ -1,2 +1,2 @@
 azure-functions
-azure-functions-db-python[all]
+azure-functions-db[all]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "azure-functions-db-python"
+name = "azure-functions-db"
 description = "Database trigger and input/output bindings for Azure Functions Python v2, powered by SQLAlchemy"
 keywords = ["azure-functions", "azure", "python", "v2", "database", "trigger", "polling", "sqlalchemy", "serverless", "binding", "input-binding", "output-binding", "decorator"]
 authors = [{ name = "Yeongseon Choe", email = "yeongseon.choe@gmail.com" }]


### PR DESCRIPTION
## Summary

The source declared \`[project].name = \"azure-functions-db-python\"\` but the package has been published to PyPI as **\`azure-functions-db\`** (0.2.1 currently live). The next release would either fail or accidentally publish to a different distribution. This is a release-blocker timebomb.

## Evidence

PyPI ground truth (HTTP status):

| Distribution name | Status |
|---|---|
| \`azure-functions-db\` | **200** (0.2.1, live) |
| \`azure-functions-db-python\` | **404** (does not exist) |

Sibling toolkit packages (logging / openapi / validation / doctor) all already publish unsuffixed, so this aligns the toolkit naming convention.

## Changes (minimal scope)

- \`pyproject.toml\`: \`[project].name\` → \`azure-functions-db\`.
- \`examples/byod_oracle/requirements.txt\`: pip target unsuffixed.
- \`examples/e2e_app/requirements.txt\`: pip target unsuffixed.
- \`README.md\`: PyPI badges and \`pip install\` snippets unsuffixed.

## Out of scope (separate doc-sync PR)

- Repository URLs (the GitHub repo IS \`azure-functions-db-python\` — not changing).
- ADRs and historical doc references that describe past state.
- \`docs/faq.md\`, \`docs/12-security.md\` install snippets.

## Verification

- \`pip install -e '.[postgres,dev]' --dry-run\`: resolves cleanly to \`azure-functions-db-0.2.1\`.
- \`pytest\`: **525 passed, 88 skipped** (skipped are environment-gated integration tests).
- \`python -m build --wheel\`: produces \`azure_functions_db-0.2.1-py3-none-any.whl\` (correct distribution filename).

## Why now

Must merge before the next \`make release-*\` invocation. Otherwise the publish workflow tags this repo's commits but tries to upload \`azure-functions-db-python\` to PyPI — a project the maintainer doesn't own and doesn't exist.