### PR TITLE
feat: DbWriter.transaction() and DbReader.scalar/one/one_or_none (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ def create_order(req: func.HttpRequest, out: DbOut) -> func.HttpResponse:
 
 Supported upsert dialects: PostgreSQL, SQLite, MySQL.
 
+`DbOut.set([])` is an explicit no-op: it accepts an empty list (e.g. when your handler computed nothing to write) and emits no SQL. Calling `set` again with a non-empty payload after a no-op still writes normally.
+
 ### Client injection (imperative escape hatches)
 
 For complex operations (multiple queries, transactions, update/delete), use `inject_reader` / `inject_writer` to receive a client instance:
@@ -254,12 +256,44 @@ def complex_read(reader: DbReader) -> None:
     user = reader.get(pk={"id": 42})
     orders = reader.query("SELECT * FROM orders WHERE user_id = :uid", params={"uid": 42})
 
+    total = reader.scalar("SELECT COUNT(*) FROM users")
+    profile = reader.one("SELECT * FROM users WHERE id = :id", params={"id": 42})
+    maybe_admin = reader.one_or_none(
+        "SELECT * FROM admins WHERE user_id = :uid", params={"uid": 42}
+    )
+
 @db.inject_writer("writer", url="%DB_URL%", table="orders")
 def complex_write(writer: DbWriter) -> None:
     writer.insert(data={"id": 1, "status": "pending"})
     writer.update(data={"status": "shipped"}, pk={"id": 1})
     writer.delete(pk={"id": 1})
 ```
+
+#### Atomic multi-statement writes — `DbWriter.transaction()`
+
+`transaction()` is a context manager that opens a single SQLAlchemy connection, begins a transaction, and shares it across every `insert` / `upsert` / `update` / `delete` call made on the same writer inside the `with` block. The transaction commits on successful exit and rolls back on any exception, including `WriteError` raised by individual write calls.
+
+```python
+@db.inject_writer("writer", url="%DB_URL%", table="orders")
+def transfer(writer: DbWriter) -> None:
+    with writer.transaction():
+        writer.insert(data={"id": 1, "status": "pending", "total": 99.99})
+        writer.update(data={"status": "shipped"}, pk={"id": 1})
+```
+
+Notes:
+
+- Nested transactions are not supported; calling `transaction()` while one is active raises `WriteError`.
+- After the `with` block exits the writer returns to its default per-call autocommit behavior.
+- `transaction()` works only on the imperative `DbWriter` (`inject_writer`). The `@db.output` `DbOut` writer commits its single `.set(...)` call atomically and does not need a transaction wrapper.
+
+#### `DbReader` row-shape helpers
+
+| Method | Rows | Behavior |
+|---|---|---|
+| `reader.scalar(sql, params=...)` | 0 or 1 | First column of the row, or `None` for zero rows. Multiple rows raise `QueryError`. |
+| `reader.one(sql, params=...)` | exactly 1 | Returns a `dict[str, object]`. Zero or multiple rows raise `QueryError`. |
+| `reader.one_or_none(sql, params=...)` | 0 or 1 | Returns a `dict[str, object]` or `None`. Multiple rows raise `QueryError`. |
 
 ### Trigger (poll-based pseudo trigger)
 
@@ -387,6 +421,16 @@ Any other database with a [SQLAlchemy dialect](https://docs.sqlalchemy.org/en/20
 - Read/write bindings via HTTP/Queue/Event triggers
 
 This package does **not** implement a native Azure Functions trigger extension. It uses a poll-based approach on top of the existing timer trigger.
+
+## Async handlers
+
+`async def` handlers are supported. SQLAlchemy operations inside `azure-functions-db` run synchronously; when an `async` handler invokes a binding (input fetch, `DbOut.set(...)`, polling commit, etc.) the package offloads the blocking call to a worker thread via `asyncio.to_thread`, so the event loop is not blocked.
+
+This package does **not** use SQLAlchemy `AsyncEngine` internally. If you need fully native asyncio drivers (e.g. `asyncpg`, `aiomysql`), drive them yourself outside the binding — `azure-functions-db` deliberately exposes a single sync engine path so behavior across dialects stays identical.
+
+## `engine_kwargs` flow-through
+
+Every binding decorator and `DbConfig` accept an `engine_kwargs` mapping that is forwarded to `sqlalchemy.create_engine`. Anything the underlying dialect supports — connection / query timeouts, pool sizing, isolation level, `connect_args`, custom event listeners — flows through unchanged. Use `EngineProvider` when several bindings should share a single engine instance with a consistent `engine_kwargs` configuration.
 
 ## Observability
 

--- a/src/azure_functions_db/binding/reader.py
+++ b/src/azure_functions_db/binding/reader.py
@@ -171,6 +171,174 @@ class DbReader:
             msg = "Failed to execute query"
             raise QueryError(msg) from exc
 
+    def scalar(
+        self,
+        sql: str,
+        *,
+        params: dict[str, object] | None = None,
+    ) -> object | None:
+        """Execute a SQL query and return a single scalar value.
+
+        Convenience wrapper around :meth:`query` for queries such as
+        ``SELECT COUNT(*) FROM ...`` or ``SELECT MAX(updated_at) FROM ...``.
+
+        Returns the first column of the first row, or ``None`` if no rows
+        match.  Raises :class:`QueryError` if the query returns more than
+        one row.
+
+        Parameters
+        ----------
+        sql:
+            SQL query string.  Use ``:name`` placeholders for parameters.
+        params:
+            Optional mapping of parameter names to values.
+
+        Returns
+        -------
+        object or None
+            The single scalar value, or ``None`` if no rows match.
+
+        Raises
+        ------
+        QueryError
+            If the query execution fails or returns multiple rows.
+        """
+        self._ensure_initialized()
+        assert self._engine is not None  # noqa: S101  # nosec B101
+
+        try:
+            stmt = text(sql)
+            with self._engine.connect() as conn:
+                if params:
+                    result = conn.execute(stmt, params)
+                else:
+                    result = conn.execute(stmt)
+                rows = result.fetchmany(2)
+        except (ConfigurationError, QueryError):
+            raise
+        except Exception as exc:
+            msg = "Failed to execute scalar query"
+            raise QueryError(msg) from exc
+
+        if not rows:
+            return None
+        if len(rows) > 1:
+            msg = "scalar() expected at most 1 row but the query returned multiple rows"
+            raise QueryError(msg)
+        # First column of the single row.
+        first_row = rows[0]
+        if hasattr(first_row, "_mapping"):
+            mapping: dict[str, object] = dict(first_row._mapping)
+            if not mapping:
+                return None
+            value: object = next(iter(mapping.values()))
+            return value
+        # Defensive fallback: row is a plain tuple-like.
+        if len(first_row):
+            fallback: object = first_row[0]
+            return fallback
+        return None
+
+    def one(
+        self,
+        sql: str,
+        *,
+        params: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        """Execute a SQL query and return exactly one row.
+
+        Convenience wrapper around :meth:`query` for queries that must
+        return a single row.
+
+        Parameters
+        ----------
+        sql:
+            SQL query string.  Use ``:name`` placeholders for parameters.
+        params:
+            Optional mapping of parameter names to values.
+
+        Returns
+        -------
+        dict
+            The single matching row as a dict.
+
+        Raises
+        ------
+        QueryError
+            If the query execution fails, returns zero rows, or returns
+            more than one row.
+        """
+        rows = self._fetch_at_most_two(sql, params)
+        if not rows:
+            msg = "one() expected exactly 1 row but the query returned no rows"
+            raise QueryError(msg)
+        if len(rows) > 1:
+            msg = "one() expected exactly 1 row but the query returned multiple rows"
+            raise QueryError(msg)
+        return rows[0]
+
+    def one_or_none(
+        self,
+        sql: str,
+        *,
+        params: dict[str, object] | None = None,
+    ) -> dict[str, object] | None:
+        """Execute a SQL query and return one row or ``None``.
+
+        Convenience wrapper around :meth:`query` for queries that must
+        return zero or one row.
+
+        Parameters
+        ----------
+        sql:
+            SQL query string.  Use ``:name`` placeholders for parameters.
+        params:
+            Optional mapping of parameter names to values.
+
+        Returns
+        -------
+        dict or None
+            The single matching row as a dict, or ``None`` if no rows
+            match.
+
+        Raises
+        ------
+        QueryError
+            If the query execution fails or returns more than one row.
+        """
+        rows = self._fetch_at_most_two(sql, params)
+        if not rows:
+            return None
+        if len(rows) > 1:
+            msg = "one_or_none() expected at most 1 row but the query returned multiple rows"
+            raise QueryError(msg)
+        return rows[0]
+
+    def _fetch_at_most_two(
+        self,
+        sql: str,
+        params: dict[str, object] | None,
+    ) -> list[dict[str, object]]:
+        """Execute *sql* and return up to two rows as dicts."""
+        self._ensure_initialized()
+        assert self._engine is not None  # noqa: S101  # nosec B101
+
+        try:
+            stmt = text(sql)
+            with self._engine.connect() as conn:
+                if params:
+                    result = conn.execute(stmt, params)
+                else:
+                    result = conn.execute(stmt)
+                rows = result.fetchmany(2)
+        except (ConfigurationError, QueryError):
+            raise
+        except Exception as exc:
+            msg = "Failed to execute query"
+            raise QueryError(msg) from exc
+
+        return [dict(row._mapping) for row in rows]
+
     def close(self) -> None:
         """Release resources held by this reader.
 

--- a/src/azure_functions_db/binding/writer.py
+++ b/src/azure_functions_db/binding/writer.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 import logging
 from types import TracebackType
 from typing import Any
 
-from sqlalchemy.engine import Engine, create_engine
+from sqlalchemy.engine import Connection, Engine, create_engine
 from sqlalchemy.schema import Table
 from sqlalchemy.sql import and_, delete, update
 
@@ -62,6 +64,71 @@ class DbWriter:
         self._table: Table | None = None
         self._owns_engine = False
         self._initialized = False
+        self._tx_conn: Connection | None = None
+
+    @contextmanager
+    def transaction(self) -> Iterator[DbWriter]:
+        """Group multiple write operations into a single SQL transaction.
+
+        Inside the ``with`` block, every call to ``insert``, ``insert_many``,
+        ``upsert``, ``upsert_many``, ``update``, and ``delete`` executes on
+        the same connection and shares one transaction.  The transaction is
+        committed on normal exit and rolled back if any exception leaves
+        the block.
+
+        Nested ``transaction()`` calls on the same writer are not supported
+        and raise :class:`WriteError`.
+
+        Example
+        -------
+        >>> with writer.transaction():
+        ...     writer.insert(data={"id": 1, "status": "pending"})
+        ...     writer.update(data={"status": "shipped"}, pk={"id": 1})
+
+        Raises
+        ------
+        WriteError
+            If a transaction is already active on this writer, if the
+            connection cannot be acquired, or if commit fails.  The
+            original exception is preserved as the cause when applicable.
+        """
+        if self._tx_conn is not None:
+            msg = (
+                "transaction() is already active on this writer; "
+                "nested transactions are not supported"
+            )
+            raise WriteError(msg)
+
+        self._ensure_initialized()
+        assert self._engine is not None  # noqa: S101  # nosec B101
+
+        try:
+            conn = self._engine.connect()
+        except Exception as exc:
+            msg = "Failed to acquire connection for transaction"
+            raise WriteError(msg) from exc
+
+        tx = conn.begin()
+        self._tx_conn = conn
+        try:
+            yield self
+        except BaseException:
+            try:
+                tx.rollback()
+            finally:
+                self._tx_conn = None
+                conn.close()
+            raise
+        else:
+            try:
+                tx.commit()
+            except Exception as exc:
+                self._tx_conn = None
+                conn.close()
+                msg = "Failed to commit transaction"
+                raise WriteError(msg) from exc
+            self._tx_conn = None
+            conn.close()
 
     def insert(self, *, data: dict[str, object]) -> None:
         """Insert a single row.
@@ -76,7 +143,7 @@ class DbWriter:
         self._validate_data_columns(data)
 
         try:
-            with self._engine.begin() as conn:
+            with self._execution_scope() as conn:
                 conn.execute(self._table.insert().values(**data))
         except (ConfigurationError, WriteError):
             raise
@@ -97,7 +164,7 @@ class DbWriter:
             self._validate_data_columns(row)
 
         try:
-            with self._engine.begin() as conn:
+            with self._execution_scope() as conn:
                 conn.execute(self._table.insert(), rows)
         except (ConfigurationError, WriteError):
             raise
@@ -125,7 +192,7 @@ class DbWriter:
 
         try:
             stmt = self._build_upsert_stmt(data, conflict_columns)
-            with self._engine.begin() as conn:
+            with self._execution_scope() as conn:
                 conn.execute(stmt)
         except (ConfigurationError, WriteError):
             raise
@@ -152,7 +219,7 @@ class DbWriter:
         self._validate_conflict_columns(conflict_columns)
 
         try:
-            with self._engine.begin() as conn:
+            with self._execution_scope() as conn:
                 for row in rows:
                     stmt = self._build_upsert_stmt(row, conflict_columns)
                     conn.execute(stmt)
@@ -177,7 +244,7 @@ class DbWriter:
         try:
             conditions = [self._table.c[col] == val for col, val in pk.items()]
             stmt: Any = update(self._table).where(and_(*conditions)).values(**data)
-            with self._engine.begin() as conn:
+            with self._execution_scope() as conn:
                 conn.execute(stmt)
         except (ConfigurationError, WriteError):
             raise
@@ -199,7 +266,7 @@ class DbWriter:
         try:
             conditions = [self._table.c[col] == val for col, val in pk.items()]
             stmt: Any = delete(self._table).where(and_(*conditions))
-            with self._engine.begin() as conn:
+            with self._execution_scope() as conn:
                 conn.execute(stmt)
         except (ConfigurationError, WriteError):
             raise
@@ -209,6 +276,16 @@ class DbWriter:
 
     def close(self) -> None:
         """Release resources held by this writer."""
+        if self._tx_conn is not None:
+            tx_conn = self._tx_conn
+            self._tx_conn = None
+            try:
+                tx_conn.close()
+            except Exception:
+                logger.warning(
+                    "Failed to close active transaction connection on writer.close()",
+                    exc_info=True,
+                )
         if self._engine is not None:
             if self._owns_engine:
                 self._engine.dispose()
@@ -231,6 +308,24 @@ class DbWriter:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    @contextmanager
+    def _execution_scope(self) -> Iterator[Connection]:
+        """Yield a connection for a single write operation.
+
+        Inside ``transaction()`` the writer reuses the active transactional
+        connection so all operations share one commit/rollback boundary.
+        Outside, each operation gets its own short-lived ``engine.begin()``
+        transaction, preserving the previous behavior.
+        """
+        assert self._engine is not None  # noqa: S101  # nosec B101
+
+        if self._tx_conn is not None:
+            yield self._tx_conn
+            return
+
+        with self._engine.begin() as conn:
+            yield conn
 
     def _ensure_initialized(self) -> None:
         if self._initialized:

--- a/tests/test_binding_reader_sugar.py
+++ b/tests/test_binding_reader_sugar.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine, insert
+
+from azure_functions_db.binding.reader import DbReader
+from azure_functions_db.core.errors import QueryError
+
+
+def _create_users_db(db_path: Path) -> str:
+    url = f"sqlite:///{db_path}"
+    engine = create_engine(url)
+    metadata = MetaData()
+    Table(
+        "users",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String(50)),
+        Column("active", Integer),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(
+            insert(metadata.tables["users"]),
+            [
+                {"id": 1, "name": "Alice", "active": 1},
+                {"id": 2, "name": "Bob", "active": 1},
+                {"id": 3, "name": "Charlie", "active": 0},
+            ],
+        )
+    engine.dispose()
+    return url
+
+
+@pytest.fixture
+def users_url(tmp_path: Path) -> str:
+    return _create_users_db(tmp_path / "users.db")
+
+
+class TestScalar:
+    def test_scalar_count(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader:
+            result = reader.scalar("SELECT COUNT(*) FROM users")
+        assert result == 3
+
+    def test_scalar_with_params(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader:
+            result = reader.scalar(
+                "SELECT COUNT(*) FROM users WHERE active = :active",
+                params={"active": 1},
+            )
+        assert result == 2
+
+    def test_scalar_returns_first_column_only(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader:
+            result = reader.scalar("SELECT name, id FROM users WHERE id = 1")
+        assert result == "Alice"
+
+    def test_scalar_no_match_returns_none(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader:
+            result = reader.scalar("SELECT name FROM users WHERE id = 999")
+        assert result is None
+
+    def test_scalar_multiple_rows_raises(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader, pytest.raises(QueryError, match="multiple"):
+            reader.scalar("SELECT name FROM users")
+
+    def test_scalar_invalid_sql_raises_query_error(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader, pytest.raises(QueryError, match="scalar query"):
+            reader.scalar("SELECT * FROM nonexistent_table")
+
+
+class TestOne:
+    def test_one_returns_single_row(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader:
+            row = reader.one("SELECT * FROM users WHERE id = 1")
+        assert row["name"] == "Alice"
+        assert row["id"] == 1
+
+    def test_one_with_params(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader:
+            row = reader.one("SELECT * FROM users WHERE id = :id", params={"id": 2})
+        assert row["name"] == "Bob"
+
+    def test_one_zero_rows_raises(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader, pytest.raises(QueryError, match="no rows"):
+            reader.one("SELECT * FROM users WHERE id = 999")
+
+    def test_one_multiple_rows_raises(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader, pytest.raises(QueryError, match="multiple"):
+            reader.one("SELECT * FROM users WHERE active = :active", params={"active": 1})
+
+
+class TestOneOrNone:
+    def test_one_or_none_returns_single_row(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader:
+            row = reader.one_or_none("SELECT * FROM users WHERE id = 1")
+        assert row is not None
+        assert row["name"] == "Alice"
+
+    def test_one_or_none_zero_rows_returns_none(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader:
+            row = reader.one_or_none("SELECT * FROM users WHERE id = 999")
+        assert row is None
+
+    def test_one_or_none_multiple_rows_raises(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader, pytest.raises(QueryError, match="multiple"):
+            reader.one_or_none("SELECT * FROM users WHERE active = 1")
+
+    def test_one_or_none_invalid_sql_raises(self, users_url: str) -> None:
+        with DbReader(url=users_url) as reader, pytest.raises(QueryError):
+            reader.one_or_none("SELECT * FROM nonexistent")

--- a/tests/test_binding_writer_transaction.py
+++ b/tests/test_binding_writer_transaction.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine, select
+
+from azure_functions_db.binding.writer import DbWriter
+from azure_functions_db.core.errors import WriteError
+
+
+def _create_users_db(db_path: Path) -> str:
+    url = f"sqlite:///{db_path}"
+    engine = create_engine(url)
+    metadata = MetaData()
+    Table(
+        "users",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String(50)),
+    )
+    metadata.create_all(engine)
+    engine.dispose()
+    return url
+
+
+def _row_count(url: str) -> int:
+    engine = create_engine(url)
+    metadata = MetaData()
+    table = Table("users", metadata, autoload_with=engine)
+    with engine.connect() as conn:
+        rows = conn.execute(select(table)).fetchall()
+    engine.dispose()
+    return len(rows)
+
+
+@pytest.fixture
+def users_url(tmp_path: Path) -> str:
+    return _create_users_db(tmp_path / "users.db")
+
+
+class TestTransactionCommit:
+    def test_transaction_commits_on_success(self, users_url: str) -> None:
+        with DbWriter(url=users_url, table="users") as writer:
+            with writer.transaction():
+                writer.insert(data={"id": 1, "name": "Alice"})
+                writer.insert(data={"id": 2, "name": "Bob"})
+        assert _row_count(users_url) == 2
+
+    def test_transaction_yields_writer_instance(self, users_url: str) -> None:
+        with DbWriter(url=users_url, table="users") as writer:
+            with writer.transaction() as tx_writer:
+                assert tx_writer is writer
+                tx_writer.insert(data={"id": 1, "name": "Alice"})
+        assert _row_count(users_url) == 1
+
+
+class TestTransactionRollback:
+    def test_transaction_rolls_back_on_exception(self, users_url: str) -> None:
+        with DbWriter(url=users_url, table="users") as writer:
+            with pytest.raises(RuntimeError, match="boom"), writer.transaction():
+                writer.insert(data={"id": 1, "name": "Alice"})
+                raise RuntimeError("boom")
+        assert _row_count(users_url) == 0
+
+    def test_transaction_rolls_back_on_write_error(self, users_url: str) -> None:
+        with DbWriter(url=users_url, table="users") as writer:
+            with pytest.raises(WriteError), writer.transaction():
+                writer.insert(data={"id": 1, "name": "Alice"})
+                writer.insert(data={"id": 1, "name": "Bob"})
+        assert _row_count(users_url) == 0
+
+
+class TestTransactionNesting:
+    def test_nested_transaction_raises(self, users_url: str) -> None:
+        with DbWriter(url=users_url, table="users") as writer:
+            with writer.transaction():
+                with pytest.raises(WriteError, match="nested"):
+                    with writer.transaction():
+                        pass
+        assert _row_count(users_url) == 0
+
+    def test_can_open_new_transaction_after_previous_completes(
+        self, users_url: str
+    ) -> None:
+        with DbWriter(url=users_url, table="users") as writer:
+            with writer.transaction():
+                writer.insert(data={"id": 1, "name": "Alice"})
+            with writer.transaction():
+                writer.insert(data={"id": 2, "name": "Bob"})
+        assert _row_count(users_url) == 2
+
+
+class TestTransactionWithMultipleOps:
+    def test_insert_update_delete_in_transaction(self, users_url: str) -> None:
+        with DbWriter(url=users_url, table="users") as writer:
+            with writer.transaction():
+                writer.insert(data={"id": 1, "name": "Alice"})
+                writer.insert(data={"id": 2, "name": "Bob"})
+                writer.update(data={"name": "Alicia"}, pk={"id": 1})
+                writer.delete(pk={"id": 2})
+        assert _row_count(users_url) == 1


### PR DESCRIPTION
## Summary

Implements the API additions and behavior clarifications from the P1 review (#95) targeted for **v0.3.0**.

### API additions
- `DbWriter.transaction()` — context manager wrapping multiple `insert` / `upsert` / `update` / `delete` calls in one SQLAlchemy transaction. Commits on success, rolls back on any exception (including `WriteError`), rejects nested transactions.
- `DbReader.scalar(sql, params=...)` — single scalar value; `None` for zero rows; raises `QueryError` on multi-row.
- `DbReader.one(sql, params=...)` — exactly one row; raises `QueryError` on zero or multi-row.
- `DbReader.one_or_none(sql, params=...)` — zero or one row; raises `QueryError` on multi-row.

Internally, the six `DbWriter` write methods now route through a private `_execution_scope()` context manager so they share the active transaction connection when one is open and otherwise use `engine.begin()` exactly as before. `close()` cleans up an outstanding transaction connection defensively.

### Documentation
- `README.md` Client injection section now shows `transaction()` plus the new reader helpers.
- New top-level notes:
  - `DbOut.set([])` is an explicit no-op (no SQL emitted).
  - Async handler model — `asyncio.to_thread` offload, no SQLAlchemy `AsyncEngine`.
  - `engine_kwargs` flow-through to `sqlalchemy.create_engine`.

### Tests
- `tests/test_binding_writer_transaction.py` — commit, rollback on exception, rollback on `WriteError`, nested rejection, reusable after completion, multi-op (insert/update/delete) in one transaction.
- `tests/test_binding_reader_sugar.py` — `scalar` / `one` / `one_or_none` zero / one / multi-row paths, params binding, invalid SQL.
- 525 → 546 tests pass; coverage gate (`fail_under = 90`) maintained.

### Out of scope (deferred to follow-up PRs)
Per the P1 checklist, these items are intentionally not in this PR:
- `DbConfig.from_env()` — helper does not yet exist; needs design + ADR before adding to public API.
- Managed Identity for SQL Server runnable example.
- `docker-compose` integration examples per dialect (PostgreSQL / MySQL / SQL Server).

These will be tracked as follow-ups so this PR stays focused on the API surface and the v0.3.0 release path.

### Validation
- `make lint` — clean (63 source files)
- `make typecheck` — clean (mypy strict)
- `make test` — 546 passed, 88 skipped (live integration only)

Refs #95