### PR TITLE
docs(examples): add runnable PostgreSQL + Azurite poll-trigger example (#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ def orders_poll(timer: func.TimerRequest, events: list[RowChange], out: DbOut) -
     ])
 ```
 
-See [`examples/trigger_with_binding/`](examples/trigger_with_binding/) for a complete runnable sample.
+See [`examples/trigger_with_binding/`](examples/trigger_with_binding/) for a complete runnable sample, or [`examples/postgresql-poll-trigger/`](examples/postgresql-poll-trigger/) for an end-to-end PostgreSQL + Azurite docker-compose setup.
 
 ## Built-in Extras
 

--- a/examples/postgresql-poll-trigger/README.md
+++ b/examples/postgresql-poll-trigger/README.md
@@ -99,12 +99,17 @@ In another terminal:
 
 ```bash
 psql "postgresql://app:app@localhost:5432/app" <<'SQL'
-INSERT INTO orders (id, customer_name, amount, status)
-VALUES (1, 'Alice', 99.99, 'pending'),
-       (2, 'Bob',   49.50, 'pending');
+-- Let BIGSERIAL allocate the ids; inserting explicit values does not
+-- advance the sequence and would collide with later auto-id inserts.
+INSERT INTO orders (customer_name, amount, status)
+VALUES ('Alice', 99.99, 'pending'),
+       ('Bob',   49.50, 'pending');
 
--- Wait for the next tick, then update one row to see another event:
-UPDATE orders SET status = 'shipped', amount = 109.99 WHERE id = 1;
+-- Wait for the next tick, then update one row to see another event.
+-- Identifying by customer_name keeps this snippet runnable without
+-- knowing the assigned ids.
+UPDATE orders SET status = 'shipped', amount = 109.99
+ WHERE customer_name = 'Alice';
 SQL
 ```
 
@@ -120,8 +125,14 @@ Verify the projection table:
 
 ```bash
 psql "postgresql://app:app@localhost:5432/app" -c \
-  "SELECT order_id, customer_name, amount, processed_at FROM processed_orders ORDER BY order_id;"
+  "SELECT order_id, source_cursor, customer_name, amount, status FROM processed_orders ORDER BY order_id, source_cursor;"
 ```
+
+You should see one row per delivered event — the initial insert produces
+one row, and the subsequent `UPDATE` produces another row with the same
+`order_id` but a later `source_cursor`. This is the strictly-idempotent
+projection pattern: replays of the same `RowChange` collide on
+`(order_id, source_cursor)` and are no-op upserts.
 
 Verify the checkpoint blob:
 
@@ -163,17 +174,34 @@ preconditions:
 
 ## Idempotent handler pattern
 
-`function_app.py` writes to `processed_orders` with
-`action="upsert"` and `conflict_columns=["order_id"]`. Because the
+`function_app.py` writes to `processed_orders` with `action="upsert"`
+and `conflict_columns=["order_id", "source_cursor"]`. Because the
 polling trigger is at-least-once, the same `RowChange` may be redelivered
 during commit failures, lease transitions, or process crashes
 (see [§4 Duplicate Window Reference](../../docs/24-polling-runtime-semantics.md#4-duplicate-window-reference)).
-The upsert collides on `order_id` and the replay becomes a no-op write of
-identical data.
+The composite key `(event.pk, event.cursor)` ensures the replay collides
+on the exact same row with byte-identical column values, so the second
+write is a true no-op.
 
-If your sink does not natively support upsert, swap the `@db.output` for an
-`inject_writer`-based handler that maintains a `processed_events` table
-keyed by `(event.pk, event.cursor)`.
+### When latest-state projection is what you want
+
+If you only need the *current* state per `order_id` (last write wins),
+key on `order_id` alone — e.g. drop `source_cursor` from the primary key
+and from `conflict_columns`. That's a simpler, smaller table, but be
+aware that:
+
+- An out-of-order replay of an older event can overwrite a newer
+  projection.
+- "Replay = no-op" only holds when the replay carries the same column
+  values as the previous delivery; for true event-level dedup, prefer
+  the composite-key pattern above.
+
+### When upsert is not available
+
+If your sink does not natively support upsert, swap the `@db.output`
+for an `inject_writer`-based handler that maintains a
+`processed_events` table keyed by `(event.pk, event.cursor)` with a
+unique constraint, and swallow the unique-violation on replay.
 
 ## Checkpoint container configuration
 

--- a/examples/postgresql-poll-trigger/README.md
+++ b/examples/postgresql-poll-trigger/README.md
@@ -1,0 +1,197 @@
+# PostgreSQL polling-trigger example
+
+End-to-end runnable example for `azure-functions-db`'s poll-based pseudo
+trigger against PostgreSQL, with checkpoints stored in
+[Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite)
+(the local Azure Storage emulator).
+
+The example polls an `orders` table on a one-minute timer, treats each row
+change as an event, and writes an idempotent projection into a
+`processed_orders` table on every tick.
+
+> Delivery is **at-least-once**. Handlers in this example are intentionally
+> idempotent — see the inline comments in `function_app.py` and the
+> [Polling Runtime & Failure Scenarios](../../docs/24-polling-runtime-semantics.md)
+> page for the full duplicate-window reference.
+
+---
+
+## What you get
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` | PostgreSQL 16 + Azurite for the checkpoint store |
+| `schema.sql` | `orders` source table (with a monotonic `updated_at` cursor and trigger), plus `processed_orders` projection |
+| `function_app.py` | A timer-driven `@db.trigger` polling `orders`, writing into `processed_orders` via `@db.output` |
+| `host.json` | Functions host config |
+| `local.settings.json.example` | All required environment variables |
+| `requirements.txt` | Function App dependencies |
+
+---
+
+## Prerequisites
+
+- Docker + Docker Compose
+- Python 3.10+
+- [Azure Functions Core Tools v4](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
+  (`func` CLI)
+- `psql` (or any PostgreSQL client) for seeding rows
+
+---
+
+## End-to-end run
+
+### 1. Start PostgreSQL and Azurite
+
+```bash
+cd examples/postgresql-poll-trigger
+docker compose up -d
+```
+
+This brings up:
+
+- `postgres` on `localhost:5432` (user `app`, password `app`, db `app`)
+- `azurite` on `localhost:10000` (Blob), `10001` (Queue), `10002` (Table)
+
+Wait until both containers report healthy:
+
+```bash
+docker compose ps
+```
+
+### 2. Initialise the schema
+
+```bash
+psql "postgresql://app:app@localhost:5432/app" -f schema.sql
+```
+
+You should see `CREATE TABLE`, `CREATE FUNCTION`, `CREATE TRIGGER` etc.
+
+### 3. Configure local settings
+
+```bash
+cp local.settings.json.example local.settings.json
+```
+
+The defaults already point at the docker-compose services and Azurite — no
+edits are needed for the happy-path local run.
+
+### 4. Install dependencies
+
+```bash
+python -m venv .venv
+source .venv/bin/activate     # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+### 5. Run the Function App
+
+```bash
+func start
+```
+
+You should see `orders_poll` registered as a Timer trigger firing every
+minute.
+
+### 6. Insert / update rows in `orders`
+
+In another terminal:
+
+```bash
+psql "postgresql://app:app@localhost:5432/app" <<'SQL'
+INSERT INTO orders (id, customer_name, amount, status)
+VALUES (1, 'Alice', 99.99, 'pending'),
+       (2, 'Bob',   49.50, 'pending');
+
+-- Wait for the next tick, then update one row to see another event:
+UPDATE orders SET status = 'shipped', amount = 109.99 WHERE id = 1;
+SQL
+```
+
+### 7. Observe events
+
+In the `func start` log you should see structured log entries like:
+
+```text
+Poller 'orders' batch <id>: processed 2 events
+```
+
+Verify the projection table:
+
+```bash
+psql "postgresql://app:app@localhost:5432/app" -c \
+  "SELECT order_id, customer_name, amount, processed_at FROM processed_orders ORDER BY order_id;"
+```
+
+Verify the checkpoint blob:
+
+```bash
+docker exec -it $(docker compose ps -q azurite) sh -c \
+  "ls -la /data/__blobstorage__ 2>/dev/null || true"
+```
+
+(or use Azure Storage Explorer pointed at `UseDevelopmentStorage=true`).
+
+### 8. Tear down
+
+```bash
+docker compose down -v   # -v also removes the postgres + azurite volumes
+```
+
+---
+
+## Cursor column choice
+
+The example uses `updated_at TIMESTAMPTZ NOT NULL` as the cursor column,
+maintained by a row-level `BEFORE INSERT OR UPDATE` trigger
+(`set_updated_at()` in `schema.sql`). This satisfies the framework's source
+preconditions:
+
+- **Monotonically non-decreasing** — every insert and update bumps
+  `updated_at` to `now()`.
+- **Stable PK / total ordering** — `(updated_at, id)` is unique enough for
+  ordered batching (the framework appends `id` as the tiebreaker via
+  `pk_columns=["id"]`).
+- **Deterministic** — the source query is a plain
+  `SELECT ... ORDER BY updated_at, id` with a `(updated_at, id)` cursor
+  filter; no application-level non-determinism.
+
+> If your real schema uses `created_at` only and rows are mutated in place,
+> you will silently miss updates. Always pick a column that is updated on
+> **every** mutation you care about, or use a soft-delete / outbox pattern.
+> See [Semantics §4 — Delete Semantics](../../docs/03-semantics.md#4-delete-semantics).
+
+## Idempotent handler pattern
+
+`function_app.py` writes to `processed_orders` with
+`action="upsert"` and `conflict_columns=["order_id"]`. Because the
+polling trigger is at-least-once, the same `RowChange` may be redelivered
+during commit failures, lease transitions, or process crashes
+(see [§4 Duplicate Window Reference](../../docs/24-polling-runtime-semantics.md#4-duplicate-window-reference)).
+The upsert collides on `order_id` and the replay becomes a no-op write of
+identical data.
+
+If your sink does not natively support upsert, swap the `@db.output` for an
+`inject_writer`-based handler that maintains a `processed_events` table
+keyed by `(event.pk, event.cursor)`.
+
+## Checkpoint container configuration
+
+`function_app.py` builds a `BlobCheckpointStore` against the container
+`db-state` in the storage account named by `AzureWebJobsStorage`. The
+container is created on first use by Azurite. In production, create it
+explicitly with the minimal RBAC needed (Storage Blob Data Contributor on
+that container only) — see
+[Checkpoint / Lease Spec §12](../../docs/06-checkpoint-lease-spec.md#12-operational-guidelines).
+
+## Tuning notes
+
+The example uses the package defaults — `batch_size=100`,
+`max_batches_per_tick=1`, `lease_ttl_seconds=120`, timer schedule
+`0 */1 * * * *` (every minute). For production sizing rules and the
+`lease_ttl_seconds` vs handler-duration relationship see
+[Polling Runtime §7](../../docs/24-polling-runtime-semantics.md#7-tuning-lease_ttl_seconds-and-timer-interval).
+
+For PostgreSQL pool settings (`pool_pre_ping`, `pool_recycle`,
+`max_overflow`) see
+[EngineProvider & Pooling §5.1](../../docs/25-engine-provider-pooling.md#51-postgresql-psycopg).

--- a/examples/postgresql-poll-trigger/docker-compose.yml
+++ b/examples/postgresql-poll-trigger/docker-compose.yml
@@ -33,7 +33,9 @@ services:
     volumes:
       - azurite-data:/data
     healthcheck:
-      test: ["CMD", "nc", "-z", "127.0.0.1", "10000"]
+      test:
+        - CMD-SHELL
+        - 'node -e "require(''net'').createConnection(10000, ''127.0.0.1'').on(''connect'', () => process.exit(0)).on(''error'', () => process.exit(1))"'
       interval: 5s
       timeout: 3s
       retries: 10

--- a/examples/postgresql-poll-trigger/docker-compose.yml
+++ b/examples/postgresql-poll-trigger/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: afdb-pg
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: app
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d app"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:latest
+    container_name: afdb-azurite
+    command: >
+      azurite
+      --blobHost 0.0.0.0
+      --queueHost 0.0.0.0
+      --tableHost 0.0.0.0
+      --location /data
+      --skipApiVersionCheck
+    ports:
+      - "10000:10000"   # Blob
+      - "10001:10001"   # Queue
+      - "10002:10002"   # Table
+    volumes:
+      - azurite-data:/data
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "10000"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  pgdata:
+  azurite-data:

--- a/examples/postgresql-poll-trigger/function_app.py
+++ b/examples/postgresql-poll-trigger/function_app.py
@@ -1,8 +1,8 @@
 """PostgreSQL polling-trigger example.
 
 This Function App polls a PostgreSQL ``orders`` table every minute via
-``@db.trigger`` and writes an idempotent projection into ``processed_orders``
-via ``@db.output``.
+``@db.trigger`` and writes a strictly-idempotent event projection into
+``processed_orders`` via ``@db.output``.
 
 Required environment variables (see local.settings.json.example):
 
@@ -15,8 +15,16 @@ Required environment variables (see local.settings.json.example):
                        ``EngineProvider`` so the connection pool is reused.
 
 Delivery is at-least-once. The handler is intentionally idempotent: it
-upserts on ``order_id`` so a replay during a commit failure, lease
-transition, or process crash produces an identical write.
+upserts on the composite key ``(order_id, source_cursor)`` so a replay
+during a commit failure, lease transition, or process crash collides on
+the exact same key and becomes a no-op write of identical data.
+
+Why a composite key? A single ``order_id`` PK would be a *latest-state
+projection* — replays still land in the same row, but a delayed replay of
+an older event could overwrite a newer projection. Keying on
+``(event.pk, event.cursor)`` instead makes "redelivery = byte-identical
+no-op" precisely true and is the canonical dedup pattern for this
+package.
 
 See:
     docs/24-polling-runtime-semantics.md  for the operational reference.
@@ -24,6 +32,8 @@ See:
 """
 
 from __future__ import annotations
+
+import os
 
 import azure.functions as func
 from azure.storage.blob import ContainerClient
@@ -62,9 +72,14 @@ source = SqlAlchemySource(
 # container.  Azurite creates the container on first use; in production,
 # pre-create it and grant the Function App identity Storage Blob Data
 # Contributor scoped to that container only.
+#
+# NOTE: ``%VAR%`` placeholder syntax is an Azure Functions binding-layer
+# feature that this package resolves for its own ``url=...`` arguments.
+# The Azure Storage SDK does *not* perform that substitution, so we read
+# the connection string from the process environment directly here.
 checkpoint_store = BlobCheckpointStore(
     container_client=ContainerClient.from_connection_string(
-        conn_str="%AzureWebJobsStorage%",
+        conn_str=os.environ["AzureWebJobsStorage"],
         container_name="db-state",
     ),
     source_fingerprint=source.source_descriptor.fingerprint,
@@ -79,7 +94,7 @@ checkpoint_store = BlobCheckpointStore(
     url="%DEST_DB_URL%",
     table="processed_orders",
     action="upsert",
-    conflict_columns=["order_id"],
+    conflict_columns=["order_id", "source_cursor"],
     engine_provider=engine_provider,
 )
 def orders_poll(
@@ -89,10 +104,15 @@ def orders_poll(
 ) -> None:
     """Project ``orders`` row changes into ``processed_orders``.
 
-    The handler is idempotent: replays of the same ``RowChange`` collide
-    on ``order_id`` and become no-op upserts.  Use ``event.pk`` and
-    ``event.cursor`` together if you need a stronger dedup key for a
-    non-upsert sink (see docs/24-polling-runtime-semantics.md §9).
+    Every projection row is keyed by ``(order_id, source_cursor)`` —
+    i.e. ``(event.pk["id"], event.cursor)``. A replay of the same
+    ``RowChange`` produces an upsert against the same composite key with
+    identical column values, so the second write is a true no-op.
+
+    For a *latest-state* projection (one row per ``order_id``, last
+    write wins) you would instead key on ``order_id`` alone — but be
+    aware that out-of-order replays could then overwrite a newer state
+    with an older one. See docs/24-polling-runtime-semantics.md §9.
     """
     del timer
 
@@ -102,6 +122,7 @@ def orders_poll(
     out.set([
         {
             "order_id": event.pk["id"],
+            "source_cursor": event.cursor,
             "customer_name": event.after["customer_name"],
             "amount": event.after["amount"],
             "status": event.after["status"],

--- a/examples/postgresql-poll-trigger/function_app.py
+++ b/examples/postgresql-poll-trigger/function_app.py
@@ -1,0 +1,112 @@
+"""PostgreSQL polling-trigger example.
+
+This Function App polls a PostgreSQL ``orders`` table every minute via
+``@db.trigger`` and writes an idempotent projection into ``processed_orders``
+via ``@db.output``.
+
+Required environment variables (see local.settings.json.example):
+
+- AzureWebJobsStorage  Connection string for the checkpoint blob container.
+                       Defaults to Azurite (``UseDevelopmentStorage=true``).
+- SOURCE_DB_URL        SQLAlchemy URL for the source database (the table
+                       the trigger polls).
+- DEST_DB_URL          SQLAlchemy URL for the destination database. May be
+                       the same database; the bindings share an
+                       ``EngineProvider`` so the connection pool is reused.
+
+Delivery is at-least-once. The handler is intentionally idempotent: it
+upserts on ``order_id`` so a replay during a commit failure, lease
+transition, or process crash produces an identical write.
+
+See:
+    docs/24-polling-runtime-semantics.md  for the operational reference.
+    docs/25-engine-provider-pooling.md    for pool tuning.
+"""
+
+from __future__ import annotations
+
+import azure.functions as func
+from azure.storage.blob import ContainerClient
+
+from azure_functions_db import (
+    BlobCheckpointStore,
+    DbBindings,
+    DbOut,
+    EngineProvider,
+    RowChange,
+    SqlAlchemySource,
+)
+
+app = func.FunctionApp()
+db = DbBindings()
+
+# Module-level EngineProvider so the source and the output binding share
+# a single SQLAlchemy engine (and therefore a single connection pool) per
+# worker process.  See docs/25-engine-provider-pooling.md.
+engine_provider = EngineProvider()
+
+# The source query is `SELECT ... FROM orders ORDER BY updated_at, id`
+# filtered by the last committed (cursor, pk) checkpoint.  ``updated_at``
+# is maintained by a BEFORE INSERT OR UPDATE trigger in schema.sql so it
+# is monotonically non-decreasing on every mutation.
+source = SqlAlchemySource(
+    url="%SOURCE_DB_URL%",
+    table="orders",
+    schema="public",
+    cursor_column="updated_at",
+    pk_columns=["id"],
+    engine_provider=engine_provider,
+)
+
+# Checkpoint and lease are stored as a single JSON blob in the ``db-state``
+# container.  Azurite creates the container on first use; in production,
+# pre-create it and grant the Function App identity Storage Blob Data
+# Contributor scoped to that container only.
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str="%AzureWebJobsStorage%",
+        container_name="db-state",
+    ),
+    source_fingerprint=source.source_descriptor.fingerprint,
+)
+
+
+@app.function_name(name="orders_poll")
+@app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
+@db.trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+@db.output(
+    "out",
+    url="%DEST_DB_URL%",
+    table="processed_orders",
+    action="upsert",
+    conflict_columns=["order_id"],
+    engine_provider=engine_provider,
+)
+def orders_poll(
+    timer: func.TimerRequest,
+    events: list[RowChange],
+    out: DbOut,
+) -> None:
+    """Project ``orders`` row changes into ``processed_orders``.
+
+    The handler is idempotent: replays of the same ``RowChange`` collide
+    on ``order_id`` and become no-op upserts.  Use ``event.pk`` and
+    ``event.cursor`` together if you need a stronger dedup key for a
+    non-upsert sink (see docs/24-polling-runtime-semantics.md §9).
+    """
+    del timer
+
+    if not events:
+        return
+
+    out.set([
+        {
+            "order_id": event.pk["id"],
+            "customer_name": event.after["customer_name"],
+            "amount": event.after["amount"],
+            "status": event.after["status"],
+            "processed_at": str(event.cursor),
+        }
+        for event in events
+        if event.after is not None
+    ])

--- a/examples/postgresql-poll-trigger/host.json
+++ b/examples/postgresql-poll-trigger/host.json
@@ -1,0 +1,11 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  }
+}

--- a/examples/postgresql-poll-trigger/local.settings.json.example
+++ b/examples/postgresql-poll-trigger/local.settings.json.example
@@ -1,0 +1,9 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "SOURCE_DB_URL": "postgresql+psycopg://app:app@localhost:5432/app",
+    "DEST_DB_URL": "postgresql+psycopg://app:app@localhost:5432/app"
+  }
+}

--- a/examples/postgresql-poll-trigger/requirements.txt
+++ b/examples/postgresql-poll-trigger/requirements.txt
@@ -1,0 +1,2 @@
+azure-functions
+azure-functions-db[postgres]

--- a/examples/postgresql-poll-trigger/schema.sql
+++ b/examples/postgresql-poll-trigger/schema.sql
@@ -25,13 +25,18 @@ CREATE TRIGGER orders_set_updated_at
     BEFORE INSERT OR UPDATE ON orders
     FOR EACH ROW EXECUTE FUNCTION set_updated_at();
 
--- Idempotent destination table.
--- The trigger handler upserts on order_id so re-delivery (at-least-once)
--- collapses into a no-op write of identical data.
+-- Strictly-idempotent destination table.
+-- The composite primary key (order_id, source_cursor) ensures that a
+-- replay of the same RowChange (at-least-once delivery) collides on the
+-- exact same row and is a no-op upsert. Keying on order_id alone would
+-- be a latest-state projection: replays still hit the same row, but an
+-- out-of-order replay of an older event could overwrite a newer state.
 CREATE TABLE IF NOT EXISTS processed_orders (
-    order_id      BIGINT PRIMARY KEY,
+    order_id      BIGINT NOT NULL,
+    source_cursor TIMESTAMPTZ NOT NULL,
     customer_name TEXT NOT NULL,
     amount        NUMERIC(12, 2) NOT NULL,
     status        TEXT NOT NULL,
-    processed_at  TIMESTAMPTZ NOT NULL
+    processed_at  TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (order_id, source_cursor)
 );

--- a/examples/postgresql-poll-trigger/schema.sql
+++ b/examples/postgresql-poll-trigger/schema.sql
@@ -1,0 +1,37 @@
+-- Source table polled by the @db.trigger.
+-- The cursor column is updated_at; a BEFORE INSERT OR UPDATE trigger
+-- guarantees it is monotonically non-decreasing on every mutation.
+CREATE TABLE IF NOT EXISTS orders (
+    id            BIGSERIAL PRIMARY KEY,
+    customer_name TEXT      NOT NULL,
+    amount        NUMERIC(12, 2) NOT NULL,
+    status        TEXT      NOT NULL DEFAULT 'pending',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS orders_updated_at_id_idx
+    ON orders (updated_at, id);
+
+CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at := now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS orders_set_updated_at ON orders;
+CREATE TRIGGER orders_set_updated_at
+    BEFORE INSERT OR UPDATE ON orders
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Idempotent destination table.
+-- The trigger handler upserts on order_id so re-delivery (at-least-once)
+-- collapses into a no-op write of identical data.
+CREATE TABLE IF NOT EXISTS processed_orders (
+    order_id      BIGINT PRIMARY KEY,
+    customer_name TEXT NOT NULL,
+    amount        NUMERIC(12, 2) NOT NULL,
+    status        TEXT NOT NULL,
+    processed_at  TIMESTAMPTZ NOT NULL
+);


### PR DESCRIPTION
## Summary

Closes #100 (P1, target v0.3.0) from the documentation umbrella #94.

Adds `examples/postgresql-poll-trigger/` — a self-contained, copy-and-runnable Function App that exercises `@db.trigger` + `@db.output` against PostgreSQL with checkpoints in Azurite. Reviewers and evaluators get a single directory they can `docker compose up` + `func start` against.

## Acceptance checklist (from #100)

- [x] Adds ` examples/postgresql-poll-trigger/` directory.
- [x] ` docker-compose.yml` brings up `postgres:16-alpine` and `mcr.microsoft.com/azure-storage/azurite:latest` with healthchecks for both.
- [x] ` schema.sql` defines an `orders` source table with a monotonic `updated_at TIMESTAMPTZ` cursor maintained by a `BEFORE INSERT OR UPDATE` trigger (`set_updated_at()`), plus the `processed_orders` projection table.
- [x] ` local.settings.json.example` lists all required env vars (`AzureWebJobsStorage`, `SOURCE_DB_URL`, `DEST_DB_URL`) with sane defaults pointing at the docker-compose services.
- [x] ` function_app.py` wires `SqlAlchemySource` + `BlobCheckpointStore` + a timer-driven `@db.trigger` with `@db.output` upsert sink, and shares a single `EngineProvider` across both bindings.
- [x] ` README.md` walks through the end-to-end run (compose up, schema init, `func start`, observe events, tear down) with verification commands for both the projection table and the checkpoint blob.
- [x] Cursor column choice and idempotent handler pattern are documented in **both** README and inline code comments / docstrings (the issue explicitly allows either; we did both).
- [x] Checkpoint container configuration documented (` db-state` container, RBAC guidance pointer to ` docs/06-checkpoint-lease-spec.md`).

## Why inline comments are kept

The repo's automated lint discourages comments in source code, but the acceptance checklist explicitly requires *\"Demonstrate cursor column choice and idempotent handler pattern in code comments or README.\"* Examples are public reference material that gets copy-pasted by users evaluating the package, so a small number of orienting comments and module/function docstrings stay. They are scoped to: the `EngineProvider` sharing rationale, the cursor monotonicity contract, and the idempotency story — each linking back to the canonical runtime docs (#108) and pooling docs (#109).

## Out of scope

- MySQL example (#105).
- SQL Server example (#106).
- Managed Identity example (#104).
- Other umbrella items (#101, #102, #103, #107).

## Validation

- `make lint` — clean.
- `make typecheck` — clean.
- `function_app.py` parses cleanly (`ast.parse`).

## References

- #94 — documentation umbrella
- #108 (#98), #109 (#99) — referenced from the example README and inline docstrings
- ` examples/trigger_with_binding/` — minimal in-repo precedent this example builds on