### PR TITLE
fix(trigger): treat LeaseConflictError as no-op in PollRunner.tick()

### DIFF
--- a/src/azure_functions_db/trigger/runner.py
+++ b/src/azure_functions_db/trigger/runner.py
@@ -26,6 +26,7 @@ from ..observability import (
     NoOpCollector,
     build_log_fields,
 )
+from ..state.errors import LeaseConflictError
 from .context import PollContext
 from .errors import (
     CommitError,
@@ -184,6 +185,22 @@ class PollRunner:
             lease_id = self._state_store.acquire_lease(
                 self._name, self._lease_ttl_seconds
             )
+        except LeaseConflictError:
+            # Scale-out contention: another instance holds the lease this
+            # cycle. Treating it as a failure (logger.exception /
+            # failures_total / LeaseAcquireError) would generate alert noise,
+            # so skip the tick silently.
+            logger.debug(
+                "Poller '%s': lease already held by another instance; skipping tick",
+                self._name,
+                extra=build_log_fields(
+                    event="lease_acquire_skipped",
+                    poller_name=self._name,
+                    invocation_id=invocation_id,
+                    result="skipped",
+                ),
+            )
+            return 0
         except Exception as exc:
             logger.exception(
                 "Failed to acquire lease for poller '%s'",

--- a/tests/test_trigger_runner.py
+++ b/tests/test_trigger_runner.py
@@ -18,6 +18,7 @@ from azure_functions_db.observability import (
     METRIC_LAST_SUCCESS_TIMESTAMP,
     NoOpCollector,
 )
+from azure_functions_db.state.errors import LeaseConflictError
 from azure_functions_db.trigger.context import PollContext
 from azure_functions_db.trigger.errors import (
     CommitError,
@@ -684,6 +685,73 @@ class TestPollRunner:
 
         with pytest.raises(LeaseAcquireError, match="Failed to acquire lease"):
             runner.tick()
+
+    def test_lease_conflict_is_silent_noop(self) -> None:
+        records: list[RawRecord] = [{"id": 1, "updated_at": 100}]
+        source = FakeSourceAdapter(batches=[records])
+        store = FakeStateStore()
+        store.acquire_error = LeaseConflictError("held by another instance")
+        store.load_error = AssertionError("checkpoint must not be loaded on conflict")
+        metrics = RecordingMetricsCollector()
+
+        handler_calls: list[list[RowChange]] = []
+
+        def handler(events: list[RowChange]) -> None:
+            handler_calls.append(events)
+
+        runner = PollRunner(
+            name="test_poller",
+            source=source,
+            state_store=store,
+            normalizer=_default_normalizer,
+            handler=handler,
+            metrics=metrics,
+        )
+
+        result = runner.tick()
+
+        assert result == 0
+        assert handler_calls == []
+        assert all(
+            name != METRIC_FAILURES_TOTAL
+            for name, _value, _labels in metrics.increments
+        )
+        assert all(
+            not (
+                name == METRIC_BATCHES_TOTAL
+                and (labels or {}).get("result") == "failure"
+            )
+            for name, _value, labels in metrics.increments
+        )
+
+    def test_lease_conflict_logs_at_debug_not_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        source = FakeSourceAdapter(batches=[])
+        store = FakeStateStore()
+        store.acquire_error = LeaseConflictError("held by another instance")
+
+        runner = PollRunner(
+            name="test_poller",
+            source=source,
+            state_store=store,
+            normalizer=_default_normalizer,
+            handler=lambda events: None,
+        )
+
+        with caplog.at_level(
+            logging.DEBUG, logger="azure_functions_db.trigger.runner"
+        ):
+            runner.tick()
+
+        assert any(
+            record.levelno == logging.DEBUG
+            and getattr(record, "event", None) == "lease_acquire_skipped"
+            for record in caplog.records
+        )
+        assert not any(
+            record.levelno >= logging.ERROR for record in caplog.records
+        )
 
     def test_fetch_failure_raises(self) -> None:
         source = FakeSourceAdapter(batches=[])


### PR DESCRIPTION
## Summary
- Catch `LeaseConflictError` separately in `PollRunner.tick()` before the generic `except Exception`
- On conflict: log at DEBUG (`event=lease_acquire_skipped`), return `0`, do NOT load checkpoint, do NOT invoke handler, do NOT emit failure metrics, do NOT raise
- True acquisition failures continue to log+meter+raise as before

## Why
In a multi-instance deployment, exactly one instance per tick wins the lease — the others legitimately fail with `LeaseConflictError`. Previously this signal fell through the generic handler and produced `logger.exception` output, incremented `azfdb_failures_total` + `azfdb_batches_total{result=failure}`, and raised `LeaseAcquireError`. This generated alert noise on every scale-out cycle.

## Tests
- `test_lease_conflict_is_silent_noop` — `LeaseConflictError` → returns 0, handler not called, checkpoint not loaded (`load_error` set as a tripwire), no `failures_total` / `batches_total{failure}` increment
- `test_lease_conflict_logs_at_debug_not_error` — only DEBUG `event=lease_acquire_skipped` log, no ERROR-level records
- Existing `test_lease_acquire_failure_raises` continues to pass (generic acquisition failure still raises `LeaseAcquireError`)
- Full suite: 548 passed, 88 skipped (integration tests requiring external services)

Closes #114
Refs umbrella #113