### PR TITLE
feat(async): add scalar/one/one_or_none to _AsyncDbReaderProxy

### DIFF
--- a/src/azure_functions_db/decorator.py
+++ b/src/azure_functions_db/decorator.py
@@ -228,6 +228,30 @@ class _AsyncDbReaderProxy:
     ) -> list[dict[str, object]]:
         return await asyncio.to_thread(self._reader.query, sql, params=params)
 
+    async def scalar(
+        self,
+        sql: str,
+        *,
+        params: dict[str, object] | None = None,
+    ) -> object | None:
+        return await asyncio.to_thread(self._reader.scalar, sql, params=params)
+
+    async def one(
+        self,
+        sql: str,
+        *,
+        params: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        return await asyncio.to_thread(self._reader.one, sql, params=params)
+
+    async def one_or_none(
+        self,
+        sql: str,
+        *,
+        params: dict[str, object] | None = None,
+    ) -> dict[str, object] | None:
+        return await asyncio.to_thread(self._reader.one_or_none, sql, params=params)
+
     def close(self) -> None:
         self._reader.close()
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -864,6 +864,62 @@ def test_inject_reader_async_proxy_query(tmp_path: Path) -> None:
     assert asyncio.run(handler()) == [{"id": 1, "name": "Alice"}, {"id": 3, "name": "Carol"}]
 
 
+def test_inject_reader_async_proxy_scalar(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "reader-async-scalar.db")
+    _create_users_table_with_data(url)
+
+    @DbBindings().inject_reader("reader", url=url, table="users")
+    async def handler(reader: Any) -> Any:
+        return await reader.scalar(
+            "SELECT COUNT(*) FROM users WHERE active = :active",
+            params={"active": 1},
+        )
+
+    assert asyncio.run(handler()) == 2
+
+
+def test_inject_reader_async_proxy_one(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "reader-async-one.db")
+    _create_users_table_with_data(url)
+
+    @DbBindings().inject_reader("reader", url=url, table="users")
+    async def handler(reader: Any) -> Any:
+        return await reader.one(
+            "SELECT id, name FROM users WHERE id = :id",
+            params={"id": 1},
+        )
+
+    assert asyncio.run(handler()) == {"id": 1, "name": "Alice"}
+
+
+def test_inject_reader_async_proxy_one_or_none_returns_row(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "reader-async-oon-some.db")
+    _create_users_table_with_data(url)
+
+    @DbBindings().inject_reader("reader", url=url, table="users")
+    async def handler(reader: Any) -> Any:
+        return await reader.one_or_none(
+            "SELECT id, name FROM users WHERE id = :id",
+            params={"id": 2},
+        )
+
+    assert asyncio.run(handler()) == {"id": 2, "name": "Bob"}
+
+
+def test_inject_reader_async_proxy_one_or_none_returns_none(tmp_path: Path) -> None:
+    url = _sqlite_url(tmp_path, "reader-async-oon-none.db")
+    _create_users_table_with_data(url)
+
+    @DbBindings().inject_reader("reader", url=url, table="users")
+    async def handler(reader: Any) -> Any:
+        return await reader.one_or_none(
+            "SELECT id, name FROM users WHERE id = :id",
+            params={"id": 9999},
+        )
+
+    assert asyncio.run(handler()) is None
+
+
 # =====================================================================
 # inject_writer tests — client injection (imperative escape hatch)
 # =====================================================================

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -920,6 +920,48 @@ def test_inject_reader_async_proxy_one_or_none_returns_none(tmp_path: Path) -> N
     assert asyncio.run(handler()) is None
 
 
+def test_inject_reader_async_proxy_one_raises_on_multiple_rows(tmp_path: Path) -> None:
+    from azure_functions_db.core.errors import QueryError
+
+    url = _sqlite_url(tmp_path, "reader-async-one-multi.db")
+    _create_users_table_with_data(url)
+
+    @DbBindings().inject_reader("reader", url=url, table="users")
+    async def handler(reader: Any) -> Any:
+        return await reader.one("SELECT id FROM users")
+
+    with pytest.raises(QueryError):
+        asyncio.run(handler())
+
+
+def test_inject_reader_async_proxy_one_or_none_raises_on_multiple_rows(tmp_path: Path) -> None:
+    from azure_functions_db.core.errors import QueryError
+
+    url = _sqlite_url(tmp_path, "reader-async-oon-multi.db")
+    _create_users_table_with_data(url)
+
+    @DbBindings().inject_reader("reader", url=url, table="users")
+    async def handler(reader: Any) -> Any:
+        return await reader.one_or_none("SELECT id FROM users")
+
+    with pytest.raises(QueryError):
+        asyncio.run(handler())
+
+
+def test_inject_reader_async_proxy_scalar_raises_on_multiple_rows(tmp_path: Path) -> None:
+    from azure_functions_db.core.errors import QueryError
+
+    url = _sqlite_url(tmp_path, "reader-async-scalar-multi.db")
+    _create_users_table_with_data(url)
+
+    @DbBindings().inject_reader("reader", url=url, table="users")
+    async def handler(reader: Any) -> Any:
+        return await reader.scalar("SELECT id FROM users")
+
+    with pytest.raises(QueryError):
+        asyncio.run(handler())
+
+
 # =====================================================================
 # inject_writer tests — client injection (imperative escape hatch)
 # =====================================================================


### PR DESCRIPTION
## Summary
- Add `async def scalar(sql, *, params=None) -> object | None` to `_AsyncDbReaderProxy`
- Add `async def one(sql, *, params=None) -> dict[str, object]`
- Add `async def one_or_none(sql, *, params=None) -> dict[str, object] | None`
- Each delegates to the corresponding sync method on `DbReader` via `asyncio.to_thread`, mirroring the existing `get` / `query` pattern

## Why
`DbReader` ships `scalar` / `one` / `one_or_none` in v0.3.0, but `_AsyncDbReaderProxy` only exposed `get` and `query`. Async handlers had no path to the row-shape helpers without dropping to sync code, breaking sync/async API parity.

## Tests
- `test_inject_reader_async_proxy_scalar` — counts active users
- `test_inject_reader_async_proxy_one` — fetches a single guaranteed row
- `test_inject_reader_async_proxy_one_or_none_returns_row` — present row → dict
- `test_inject_reader_async_proxy_one_or_none_returns_none` — missing row → None
- Full suite: 550 passed, 88 skipped

Closes #115
Refs umbrella #113