### PR TITLE
fix(engine): reject connect_args inside engine_kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,9 @@ This package does **not** use SQLAlchemy `AsyncEngine` internally. If you need f
 
 ## `engine_kwargs` flow-through
 
-Every binding decorator and `DbConfig` accept an `engine_kwargs` mapping that is forwarded to `sqlalchemy.create_engine`. Anything the underlying dialect supports — connection / query timeouts, pool sizing, isolation level, `connect_args`, custom event listeners — flows through unchanged. Use `EngineProvider` when several bindings should share a single engine instance with a consistent `engine_kwargs` configuration.
+Every binding decorator and `DbConfig` accept an `engine_kwargs` mapping that is forwarded to `sqlalchemy.create_engine`. Anything the underlying dialect supports — connection / query timeouts, pool sizing, isolation level, custom event listeners — flows through unchanged. Use `EngineProvider` when several bindings should share a single engine instance with a consistent `engine_kwargs` configuration.
+
+> **Note:** Pass driver-level `connect_args` via the dedicated `connect_args` parameter, **not** nested inside `engine_kwargs`. Nesting `connect_args` inside `engine_kwargs` raises `ConfigurationError` because `EngineProvider` already owns that argument and silently overriding it would mask user intent.
 
 > See [EngineProvider Lifecycle & SQLAlchemy Pooling Guidance](docs/25-engine-provider-pooling.md) for engine cache-key rules, recommended pool settings on Azure Functions (`pool_pre_ping`, `pool_recycle`, `pool_size` / `max_overflow`), per-dialect snippets, and SQLite test caveats.
 

--- a/src/azure_functions_db/core/engine.py
+++ b/src/azure_functions_db/core/engine.py
@@ -6,6 +6,7 @@ import threading
 from sqlalchemy.engine import Engine, create_engine
 
 from .config import DbConfig, resolve_env_vars
+from .errors import ConfigurationError
 
 
 class EngineProvider:
@@ -23,6 +24,14 @@ class EngineProvider:
             return engine
 
     def create_isolated_engine(self, config: DbConfig) -> Engine:
+        if "connect_args" in config.engine_kwargs:
+            msg = (
+                "Do not pass 'connect_args' inside engine_kwargs; "
+                "use DbConfig.connect_args instead. Mixing the two would "
+                "silently let engine_kwargs override DbConfig.connect_args."
+            )
+            raise ConfigurationError(msg)
+
         kwargs: dict[str, object] = {
             "pool_size": config.pool_size,
             "pool_recycle": config.pool_recycle,

--- a/tests/test_shared_core.py
+++ b/tests/test_shared_core.py
@@ -187,6 +187,20 @@ class TestEngineProvider:
         assert engine_a is not engine_b
         provider.dispose_all()
 
+    def test_connect_args_inside_engine_kwargs_raises(self, tmp_path: Path) -> None:
+        from azure_functions_db.core.errors import ConfigurationError
+
+        url = _create_orders_db(tmp_path / "kwargs_conflict.db")
+        provider = EngineProvider()
+        config = DbConfig(
+            connection_url=url,
+            connect_args={"timeout": 5},
+            engine_kwargs={"connect_args": {"timeout": 30}},
+        )
+
+        with pytest.raises(ConfigurationError, match="connect_args"):
+            provider.get_engine(config)
+
 
 class TestSerializers:
     def test_serialize_cursor_part_datetime(self) -> None:

--- a/tests/test_shared_core.py
+++ b/tests/test_shared_core.py
@@ -201,6 +201,38 @@ class TestEngineProvider:
         with pytest.raises(ConfigurationError, match="connect_args"):
             provider.get_engine(config)
 
+    def test_connect_args_in_engine_kwargs_alone_still_raises(self, tmp_path: Path) -> None:
+        from azure_functions_db.core.errors import ConfigurationError
+
+        url = _create_orders_db(tmp_path / "kwargs_alone.db")
+        provider = EngineProvider()
+        config = DbConfig(
+            connection_url=url,
+            engine_kwargs={"connect_args": {"timeout": 30}},
+        )
+
+        with pytest.raises(ConfigurationError, match="connect_args"):
+            provider.get_engine(config)
+
+    def test_connect_args_error_message_directs_to_dbconfig_connect_args(
+        self, tmp_path: Path
+    ) -> None:
+        from azure_functions_db.core.errors import ConfigurationError
+
+        url = _create_orders_db(tmp_path / "kwargs_msg.db")
+        provider = EngineProvider()
+        config = DbConfig(
+            connection_url=url,
+            engine_kwargs={"connect_args": {"timeout": 30}},
+        )
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            provider.get_engine(config)
+
+        message = str(exc_info.value)
+        assert "engine_kwargs" in message
+        assert "DbConfig.connect_args" in message
+
 
 class TestSerializers:
     def test_serialize_cursor_part_datetime(self) -> None:


### PR DESCRIPTION
## Summary
- Detect `connect_args` keys inside `DbConfig.engine_kwargs` in `EngineProvider.create_isolated_engine()` and raise `ConfigurationError` before calling `create_engine`
- Error message points the caller to `DbConfig.connect_args` as the single source of truth

## Why
Previously the method seeded `kwargs[\"connect_args\"]` from `DbConfig.connect_args`, then ran `kwargs.update(config.engine_kwargs)`. If a caller (or library wrapper) supplied `connect_args` through both fields, the `engine_kwargs` copy silently overrode the explicit `DbConfig.connect_args`. For options like SSL context, statement timeouts, or app name, that silent override is a security/correctness footgun.

Failing fast at config time is consistent with how `pool_size`, `pool_recycle`, and `echo` already have a single canonical channel.

## Tests
- `test_connect_args_inside_engine_kwargs_raises` — providing `connect_args` in both fields raises `ConfigurationError` matching `connect_args`
- Existing `engine_kwargs` passthrough / cache-key tests continue to pass
- Full suite: 547 passed, 88 skipped

Closes #117
Refs umbrella #113