### PR TITLE
docs(async): document async writer transaction limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,33 @@ This package does **not** implement a native Azure Functions trigger extension. 
 
 This package does **not** use SQLAlchemy `AsyncEngine` internally. If you need fully native asyncio drivers (e.g. `asyncpg`, `aiomysql`), drive them yourself outside the binding — `azure-functions-db` deliberately exposes a single sync engine path so behavior across dialects stays identical.
 
+### Async writer transactions
+
+The async writer proxy injected by `@db.inject_writer` into `async def` handlers exposes `insert`, `insert_many`, `upsert`, `upsert_many`, and `close` — but **does not** expose a `transaction()` context manager. SQLAlchemy `Connection` / `Transaction` objects are not safe to share across threads, and `asyncio.to_thread` does not pin work to a single OS thread, so a per-call async transaction would silently break atomicity.
+
+If you need multi-statement atomicity from an async handler, wrap the entire transactional unit in a single `asyncio.to_thread` call that drives a synchronous `DbWriter` end-to-end:
+
+```python
+import asyncio
+from azure_functions_db import DbWriter
+
+
+def _transfer(url: str) -> None:
+    writer = DbWriter(url=url, table="orders")
+    try:
+        with writer.transaction():
+            writer.insert(data={"id": 1, "status": "pending"})
+            writer.update(data={"status": "shipped"}, pk={"id": 1})
+    finally:
+        writer.close()
+
+
+async def handler() -> None:
+    await asyncio.to_thread(_transfer, "%DB_URL%")
+```
+
+A native async transaction context manager may be added in a future release.
+
 ## `engine_kwargs` flow-through
 
 Every binding decorator and `DbConfig` accept an `engine_kwargs` mapping that is forwarded to `sqlalchemy.create_engine`. Anything the underlying dialect supports — connection / query timeouts, pool sizing, isolation level, `connect_args`, custom event listeners — flows through unchanged. Use `EngineProvider` when several bindings should share a single engine instance with a consistent `engine_kwargs` configuration.

--- a/src/azure_functions_db/decorator.py
+++ b/src/azure_functions_db/decorator.py
@@ -233,6 +233,32 @@ class _AsyncDbReaderProxy:
 
 
 class _AsyncDbWriterProxy:
+    """Async wrapper around :class:`DbWriter` for async handlers.
+
+    Each write call is offloaded to a worker thread via
+    :func:`asyncio.to_thread` so the event loop is not blocked.
+
+    Limitation: this proxy intentionally does not expose
+    :meth:`DbWriter.transaction`. SQLAlchemy ``Connection`` /
+    ``Transaction`` objects are not safe to share across threads, and
+    :func:`asyncio.to_thread` does not pin the work to a single thread.
+    For multi-statement atomicity from an async handler, wrap the entire
+    transactional unit in a single :func:`asyncio.to_thread` call that
+    drives a synchronous :class:`DbWriter` end-to-end::
+
+        def _do_transfer(url: str) -> None:
+            writer = DbWriter(url=url, table="orders")
+            try:
+                with writer.transaction():
+                    writer.insert(data={...})
+                    writer.update(data={...}, pk={...})
+            finally:
+                writer.close()
+
+        async def handler() -> None:
+            await asyncio.to_thread(_do_transfer, url)
+    """
+
     def __init__(self, writer: DbWriter) -> None:
         self._writer = writer
 


### PR DESCRIPTION
## Priority: P1 (target v0.3.0)

## Context

Closes #116. Refs umbrella #113. Follow-up issue: #128.

The async writer proxy injected by \`@db.inject_writer\` into async handlers exposes \`insert\` / \`insert_many\` / \`upsert\` / \`upsert_many\` / \`close\`, but **not** \`transaction()\`. Implementing a true async transaction is non-trivial (SQLAlchemy \`Connection\` / \`Transaction\` are not thread-safe; \`asyncio.to_thread\` does not pin work to a single thread), so v0.3.0 takes the safe path: document the limitation and the recommended workaround.

## Acceptance Checklist

- [x] Class docstring on \`_AsyncDbWriterProxy\` spelling out the limitation and the workaround.
- [x] README \`Async handlers\` section gets a new \`Async writer transactions\` subsection with a working example.
- [x] Follow-up issue opened tracking the native async transaction implementation: #128.
- [x] \`make lint\` / \`make typecheck\` / \`make test\` all green.

## Out of scope

- Implementing the async transaction context manager (deferred to #128).

## References

- Umbrella: #113
- Follow-up: #128
- src/azure_functions_db/decorator.py \`_AsyncDbWriterProxy\`