### PR TITLE
test(examples): add PostgreSQL poll-trigger smoke script

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -67,3 +67,15 @@ jobs:
 
       - name: Run catch-up benchmark
         run: python benchmarks/bench_catchup.py
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Lint shell scripts
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq shellcheck
+          shellcheck examples/postgresql-poll-trigger/smoke.sh

--- a/examples/postgresql-poll-trigger/README.md
+++ b/examples/postgresql-poll-trigger/README.md
@@ -41,6 +41,13 @@ change as an event, and writes an idempotent projection into a
 
 ## End-to-end run
 
+> **Verify your environment first**: run [`./smoke.sh`](smoke.sh) to bring
+> up Postgres + Azurite, apply the schema, drive a single poll tick from
+> Python, and assert the projection table received the expected rows. The
+> script is self-contained (no `func` CLI required) and exits non-zero on
+> any failure. Use it as a smoke test in CI or as a sanity check before
+> running the full Functions host below.
+
 ### 1. Start PostgreSQL and Azurite
 
 ```bash

--- a/examples/postgresql-poll-trigger/function_app.py
+++ b/examples/postgresql-poll-trigger/function_app.py
@@ -119,14 +119,23 @@ def orders_poll(
     if not events:
         return
 
+    # `event.cursor` is a tuple aligned with the source's
+    # `(cursor_column, *pk_columns)` ordering — here `(updated_at, id)`. The
+    # first element is the source-side change timestamp (TIMESTAMPTZ); we
+    # persist that as `source_cursor`. `processed_at` records when *we*
+    # observed the event, so it is wall-clock `now()`, not the source cursor.
+    from datetime import datetime, timezone
+
+    processed_at = datetime.now(timezone.utc)
+
     out.set([
         {
             "order_id": event.pk["id"],
-            "source_cursor": event.cursor,
+            "source_cursor": event.cursor[0],
             "customer_name": event.after["customer_name"],
             "amount": event.after["amount"],
             "status": event.after["status"],
-            "processed_at": str(event.cursor),
+            "processed_at": processed_at,
         }
         for event in events
         if event.after is not None

--- a/examples/postgresql-poll-trigger/smoke.sh
+++ b/examples/postgresql-poll-trigger/smoke.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# End-to-end smoke test for the PostgreSQL polling-trigger example.
+#
+# Brings up Postgres + Azurite via docker compose, applies the schema,
+# inserts and updates a row, and verifies that the package's polling
+# logic produces the expected projection. Does NOT run `func start`
+# (that requires the Azure Functions Core Tools and a long-lived
+# process); instead it drives a single poll tick from Python so the
+# script stays self-contained and CI-friendly.
+#
+# Exits non-zero on any failure with a message identifying the step.
+
+set -euo pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly EXAMPLE_DIR
+readonly PG_URL="postgresql+psycopg://app:app@localhost:5432/app"
+readonly AZURITE_CONN_STR="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;TableEndpoint=http://localhost:10002/devstoreaccount1;"
+readonly CONTAINER_NAME="db-state"
+
+log() { printf '\n[smoke] %s\n' "$*"; }
+fail() { printf '\n[smoke][FAIL] %s\n' "$*" >&2; exit 1; }
+
+cd "${EXAMPLE_DIR}"
+
+command -v docker >/dev/null || fail "docker is required"
+command -v psql >/dev/null || fail "psql is required (apt-get install postgresql-client)"
+command -v python3 >/dev/null || fail "python3 is required"
+
+log "1/7 docker compose up"
+docker compose up -d || fail "docker compose up failed"
+
+log "2/7 wait for Postgres healthcheck"
+for _ in $(seq 1 30); do
+    if docker compose ps --format json postgres 2>/dev/null | grep -q '"Health":"healthy"'; then
+        break
+    fi
+    sleep 2
+done
+docker compose ps --format json postgres 2>/dev/null | grep -q '"Health":"healthy"' \
+    || fail "Postgres did not become healthy within 60s"
+
+log "3/7 apply schema"
+PGPASSWORD=app psql "postgresql://app:app@localhost:5432/app" -v ON_ERROR_STOP=1 \
+    -f schema.sql >/dev/null || fail "schema.sql failed"
+
+log "4/7 install Python dependencies"
+python3 -m venv .smoke-venv
+# shellcheck disable=SC1091
+source .smoke-venv/bin/activate
+pip install --quiet --upgrade pip
+pip install --quiet \
+    "azure-functions-db[postgres] @ file://${EXAMPLE_DIR}/../.." \
+    azure-storage-blob \
+    psycopg[binary] \
+    || fail "pip install failed"
+
+log "5/7 seed orders rows"
+PGPASSWORD=app psql "postgresql://app:app@localhost:5432/app" -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+TRUNCATE orders, processed_orders RESTART IDENTITY;
+INSERT INTO orders (customer_name, amount, status)
+VALUES ('Alice', 99.99, 'pending'),
+       ('Bob',   49.50, 'pending');
+UPDATE orders SET status = 'shipped', amount = 109.99
+ WHERE customer_name = 'Alice';
+SQL
+
+log "6/7 drive one poll tick from Python and assert projection"
+PG_URL="${PG_URL}" \
+AZURITE_CONN_STR="${AZURITE_CONN_STR}" \
+CONTAINER_NAME="${CONTAINER_NAME}" \
+python3 - <<'PY'
+import os
+import sys
+
+from azure.storage.blob import ContainerClient
+from sqlalchemy import create_engine, text
+
+from azure_functions_db import (
+    BlobCheckpointStore,
+    PollTrigger,
+    RowChange,
+    SqlAlchemySource,
+)
+
+pg_url = os.environ["PG_URL"]
+azurite = os.environ["AZURITE_CONN_STR"]
+container_name = os.environ["CONTAINER_NAME"]
+
+container = ContainerClient.from_connection_string(
+    conn_str=azurite, container_name=container_name
+)
+try:
+    container.create_container()
+except Exception:
+    pass
+
+source = SqlAlchemySource(
+    url=pg_url,
+    table="orders",
+    cursor_column="updated_at",
+    pk_columns=["id"],
+)
+checkpoint_store = BlobCheckpointStore(
+    container_client=container,
+    source_fingerprint=source.source_descriptor.fingerprint,
+)
+
+dest_engine = create_engine(pg_url)
+
+
+def handle(events: list[RowChange]) -> None:
+    if not events:
+        return
+    rows = [
+        {
+            "order_id": e.pk["id"],
+            "source_cursor": e.cursor,
+            "customer_name": (e.after or {}).get("customer_name"),
+            "amount": (e.after or {}).get("amount"),
+            "status": (e.after or {}).get("status"),
+        }
+        for e in events
+        if e.after is not None
+    ]
+    with dest_engine.begin() as conn:
+        for row in rows:
+            conn.execute(
+                text(
+                    "INSERT INTO processed_orders "
+                    "(order_id, source_cursor, customer_name, amount, status) "
+                    "VALUES (:order_id, :source_cursor, :customer_name, :amount, :status) "
+                    "ON CONFLICT (order_id, source_cursor) DO NOTHING"
+                ),
+                row,
+            )
+
+
+trigger = PollTrigger(
+    name="orders",
+    source=source,
+    checkpoint_store=checkpoint_store,
+)
+batches = trigger.run(timer=None, handler=handle)
+print(f"[smoke] poll tick processed {batches} batch(es)")
+
+with dest_engine.begin() as conn:
+    count = conn.execute(text("SELECT COUNT(*) FROM processed_orders")).scalar_one()
+
+if count < 2:
+    print(
+        f"[smoke][FAIL] expected at least 2 processed_orders rows, got {count}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+blobs = list(container.list_blobs())
+if not blobs:
+    print("[smoke][FAIL] no checkpoint blob present in Azurite", file=sys.stderr)
+    sys.exit(1)
+
+print(f"[smoke] processed_orders rows: {count}")
+print(f"[smoke] checkpoint blobs: {[b.name for b in blobs]}")
+PY
+
+log "7/7 teardown"
+docker compose down -v >/dev/null
+rm -rf .smoke-venv
+
+log "OK — smoke test passed"

--- a/examples/postgresql-poll-trigger/smoke.sh
+++ b/examples/postgresql-poll-trigger/smoke.sh
@@ -9,7 +9,12 @@
 # process); instead it drives a single poll tick from Python so the
 # script stays self-contained and CI-friendly.
 #
+# Requires Docker Compose v2 (`docker compose ...`, not `docker-compose`)
+# because we rely on `--format json` and `up --wait`.
+#
 # Exits non-zero on any failure with a message identifying the step.
+# Always tears down docker resources and the temporary venv on exit,
+# even if a step fails.
 
 set -euo pipefail
 
@@ -22,24 +27,32 @@ readonly CONTAINER_NAME="db-state"
 log() { printf '\n[smoke] %s\n' "$*"; }
 fail() { printf '\n[smoke][FAIL] %s\n' "$*" >&2; exit 1; }
 
+cleanup() {
+    local rc=$?
+    log "cleanup (exit=${rc})"
+    (cd "${EXAMPLE_DIR}" && docker compose down -v >/dev/null 2>&1) || true
+    rm -rf "${EXAMPLE_DIR}/.smoke-venv"
+    exit "${rc}"
+}
+trap cleanup EXIT
+
 cd "${EXAMPLE_DIR}"
 
 command -v docker >/dev/null || fail "docker is required"
 command -v psql >/dev/null || fail "psql is required (apt-get install postgresql-client)"
 command -v python3 >/dev/null || fail "python3 is required"
+docker compose version >/dev/null 2>&1 \
+    || fail "docker compose v2 is required (this script uses 'up --wait' and '--format json')"
 
-log "1/7 docker compose up"
-docker compose up -d || fail "docker compose up failed"
+log "1/7 docker compose up (waiting for healthchecks)"
+docker compose up -d --wait || fail "docker compose up --wait failed"
 
-log "2/7 wait for Postgres healthcheck"
-for _ in $(seq 1 30); do
-    if docker compose ps --format json postgres 2>/dev/null | grep -q '"Health":"healthy"'; then
-        break
-    fi
-    sleep 2
+log "2/7 verify Postgres and Azurite are healthy"
+for service in postgres azurite; do
+    docker compose ps --format json "${service}" 2>/dev/null \
+        | grep -q '"Health":"healthy"' \
+        || fail "${service} did not become healthy"
 done
-docker compose ps --format json postgres 2>/dev/null | grep -q '"Health":"healthy"' \
-    || fail "Postgres did not become healthy within 60s"
 
 log "3/7 apply schema"
 PGPASSWORD=app psql "postgresql://app:app@localhost:5432/app" -v ON_ERROR_STOP=1 \
@@ -73,6 +86,7 @@ CONTAINER_NAME="${CONTAINER_NAME}" \
 python3 - <<'PY'
 import os
 import sys
+from datetime import datetime, timezone
 
 from azure.storage.blob import ContainerClient
 from sqlalchemy import create_engine, text
@@ -113,13 +127,16 @@ dest_engine = create_engine(pg_url)
 def handle(events: list[RowChange]) -> None:
     if not events:
         return
+    processed_at = datetime.now(timezone.utc)
     rows = [
         {
             "order_id": e.pk["id"],
-            "source_cursor": e.cursor,
+            # event.cursor is (cursor_column, *pk_columns) — keep the timestamp.
+            "source_cursor": e.cursor[0],
             "customer_name": (e.after or {}).get("customer_name"),
             "amount": (e.after or {}).get("amount"),
             "status": (e.after or {}).get("status"),
+            "processed_at": processed_at,
         }
         for e in events
         if e.after is not None
@@ -129,8 +146,9 @@ def handle(events: list[RowChange]) -> None:
             conn.execute(
                 text(
                     "INSERT INTO processed_orders "
-                    "(order_id, source_cursor, customer_name, amount, status) "
-                    "VALUES (:order_id, :source_cursor, :customer_name, :amount, :status) "
+                    "(order_id, source_cursor, customer_name, amount, status, processed_at) "
+                    "VALUES (:order_id, :source_cursor, :customer_name, :amount, :status, "
+                    ":processed_at) "
                     "ON CONFLICT (order_id, source_cursor) DO NOTHING"
                 ),
                 row,
@@ -142,8 +160,8 @@ trigger = PollTrigger(
     source=source,
     checkpoint_store=checkpoint_store,
 )
-batches = trigger.run(timer=None, handler=handle)
-print(f"[smoke] poll tick processed {batches} batch(es)")
+events_processed = trigger.run(timer=None, handler=handle)
+print(f"[smoke] poll tick processed {events_processed} event(s)")
 
 with dest_engine.begin() as conn:
     count = conn.execute(text("SELECT COUNT(*) FROM processed_orders")).scalar_one()
@@ -164,8 +182,5 @@ print(f"[smoke] processed_orders rows: {count}")
 print(f"[smoke] checkpoint blobs: {[b.name for b in blobs]}")
 PY
 
-log "7/7 teardown"
-docker compose down -v >/dev/null
-rm -rf .smoke-venv
-
+log "7/7 assertions passed (cleanup runs via EXIT trap)"
 log "OK — smoke test passed"

--- a/examples/postgresql-poll-trigger/smoke.sh
+++ b/examples/postgresql-poll-trigger/smoke.sh
@@ -88,6 +88,7 @@ import os
 import sys
 from datetime import datetime, timezone
 
+from azure.core.exceptions import ResourceExistsError
 from azure.storage.blob import ContainerClient
 from sqlalchemy import create_engine, text
 
@@ -107,7 +108,7 @@ container = ContainerClient.from_connection_string(
 )
 try:
     container.create_container()
-except Exception:
+except ResourceExistsError:
     pass
 
 source = SqlAlchemySource(


### PR DESCRIPTION
## Priority: P2 (target v0.3.0)

## Context
The PostgreSQL polling-trigger example (`examples/postgresql-poll-trigger/`) is the canonical end-to-end demonstration of the package, but had no automated way to verify it actually works. Setting it up requires the Azure Functions Core Tools, a long-lived `func start` process, and manual SQL seeding — too heavy for CI and too much friction for contributors who just want a sanity check.

## What this PR does
Adds `examples/postgresql-poll-trigger/smoke.sh`, a self-contained bash script that:

1. Brings up Postgres + Azurite via `docker compose up -d --wait` (Compose v2 required).
2. Verifies both services reached `healthy`.
3. Applies `schema.sql`.
4. Installs the package from the local checkout into a temporary venv.
5. Seeds 2 inserts + 1 update into `orders`.
6. Drives **a single poll tick directly via `PollTrigger.run(timer=None, handler=...)`** (no `func` CLI required) and asserts:
   - `processed_orders` received ≥ 2 rows.
   - A checkpoint blob exists in the Azurite container.
7. Tears down via an `EXIT` trap so failure paths don't leak containers/volumes/venv.

Also wires a `shellcheck` job into `ci-test.yml` so the script is linted on every PR.

## Drive-by bug fix
Oracle review of the smoke script surfaced that `function_app.py` was misusing `event.cursor`: the cursor is a tuple shaped by `(cursor_column, *pk_columns)` (here `(updated_at, id)`), not a scalar. The example was writing the whole tuple into a `TIMESTAMPTZ` column, which would fail at runtime. `function_app.py` now correctly extracts `event.cursor[0]` for `source_cursor` and uses wall-clock `now()` for `processed_at`.

## Acceptance Checklist
- [x] `examples/postgresql-poll-trigger/smoke.sh` is executable, `shellcheck` clean, and `bash -n` clean.
- [x] CI runs `shellcheck` on the script (`shellcheck` job in `ci-test.yml`).
- [x] Cleanup happens via `trap cleanup EXIT` — no leaked docker resources or venv on failure.
- [x] Compose v2 requirement is verified explicitly with a clear error message if missing.
- [x] `function_app.py` no longer writes a tuple into a TIMESTAMPTZ column.
- [x] Example README points users at `smoke.sh` as the "verify your environment" step.
- [x] `make lint` / `make typecheck` / `make test` all green (546 tests pass, no diagnostic regressions).

## Out of scope
- Running the smoke script live in CI (would require docker-in-docker or a self-hosted runner). Tracked separately if needed; for now CI only lints the script.
- Refactoring `function_app.py` to share the projection helper with `smoke.sh` (kept as duplicate to keep the example self-contained).

## References
- Closes #120
- Refs #113 (release-readiness umbrella)
- Oracle review (background task `bg_d57a4843`) — found the cursor-tuple bug and the missing EXIT trap.