### PR TITLE
ci: allow 'test/' branch prefix in branch-naming-validation

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -151,6 +151,7 @@ jobs:
               /^docs\/.+$/,
               /^chore\/.+$/,
               /^ci\/.+$/,
+              /^test\/.+$/,
               /^codex\/.+$/,
               /^main$/
             ];
@@ -166,6 +167,7 @@ jobs:
                 - docs/<description>
                 - chore/<description>
                 - ci/<description>
+                - test/<description>
                 - codex/<description>
                 - main`);
             } else {


### PR DESCRIPTION
## Priority: P1 (unblocks v0.3.0 release)

## Context
\`AGENTS.md\` lists \`test:\` as a valid Conventional Commit prefix, and several v0.3.0 PRs follow that convention on the branch name (\`test/120-postgres-smoke-script\`, \`test/121-observability-metric-drift\`). However \`.github/workflows/stale.yml\` only allows \`feat/fix/docs/chore/ci/dependabot/codex\`, so those PRs fail CI on a naming check instead of being graded on their substance, which then blocks the v0.3.0 release train.

## What this PR does
Adds \`/^test\\/.+\$/\` to the \`validPatterns\` allowlist in the \`branch-naming-validation\` job and includes \`test/\` in the failure-message help text. No behavior change for any other branch type.

## Acceptance Checklist
- [x] \`test/<description>\` branches pass branch-naming-validation.
- [x] All previously valid prefixes still pass.
- [x] Failure message lists \`test/\` so future contributors see it.

## References
- AGENTS.md → "Issue Conventions → Title" (lists \`test:\` as a valid prefix)
- Unblocks: #127, #130