### PR TITLE
chore(ci): standardize Action pinning to immutable SHAs

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.10' && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
@@ -53,10 +53,10 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Lint shell scripts
         run: |

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Start Azurite with skipApiVersionCheck
         run: |
@@ -75,7 +75,7 @@ jobs:
           sleep 3
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload integration test report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration-report-${{ matrix.db }}-${{ github.run_id }}
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -42,7 +42,7 @@ jobs:
       resource_group: ${{ steps.names.outputs.rg }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Compute resource names
         id: names
@@ -57,7 +57,7 @@ jobs:
           echo "st=${ST}"   >> "$GITHUB_OUTPUT"
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3.0.0
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -82,7 +82,7 @@ jobs:
                 enableAppInsights=false
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload e2e report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: e2e-report/
@@ -124,7 +124,7 @@ jobs:
     if: always() && needs.check_secrets.outputs.has_azure == 'true'
     steps:
       - name: Azure login (OIDC)
-        uses: azure/login@v3.0.0
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -60,4 +60,7 @@ jobs:
           hatch build --clean
 
       - name: Publish to PyPI
+        # Documented exception to the SHA-pinning policy: PyPA officially
+        # recommends pinning to the rolling `release/v1` branch. See
+        # CONTRIBUTING.md "GitHub Actions Pinning" for rationale.
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - Semantics changes require ADR or design note.
 - Never suppress type errors.
 - Guarantee claims must be honest (pseudo trigger, at-least-once).
+- Pin every external GitHub Action `uses:` ref to a full commit SHA with a `# vX.Y.Z` comment. See [`CONTRIBUTING.md` § "GitHub Actions Pinning"](CONTRIBUTING.md#github-actions-pinning) for the policy and approved exceptions.
 
 ## Issue Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,51 @@ make cov         # Run tests with coverage
 make check-all   # Run the full local gate
 ```
 
+## GitHub Actions Pinning
+
+All external `uses:` references in `.github/workflows/` MUST pin to a
+full 40-character commit SHA with a trailing comment documenting the
+released version or channel. Example:
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+```
+
+This applies to first-party (`actions/*`, `github/*`, `azure/*`) and
+third-party Actions alike.
+
+**Rationale.** Mutable tags (including immutable-looking version tags
+like `@v6.0.1`) can be retroactively moved by an attacker who gains
+write access to the upstream repository. The
+[`tj-actions/changed-files` compromise (CVE-2025-30066, March 2025)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066)
+demonstrated this exact failure mode: ~23,000 repositories had their CI
+secrets exfiltrated, and only workflows that pinned to a commit SHA were
+safe. GitHub's own guidance now identifies SHA pinning as
+[the only way to use an Action as an immutable release](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions),
+and OpenSSF Scorecard's
+[`Pinned-Dependencies` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
+flags anything weaker as Medium-risk.
+
+Dependabot updates SHA-pinned references on the configured schedule and
+keeps the trailing version comment in sync, so the human-readable
+context never drifts from the pinned commit.
+
+**Approved exceptions.** The following mutable refs are the only ones
+permitted in this repository and are flagged with an inline comment at
+the call site:
+
+- `pypa/gh-action-pypi-publish@release/v1` — PyPA-maintained stable
+  release channel; this pinning style is explicitly recommended upstream.
+- Local composite actions (`uses: ./...`) — versioned with the repo.
+
+When adding a new external Action, run `git ls-remote <repo-url> <tag>`
+to resolve the SHA, then pin to the dereferenced commit
+(`<sha>^{}` form):
+
+```bash
+git ls-remote https://github.com/actions/checkout refs/tags/v6
+```
+
 ## Example Coverage Policy
 
 Examples are part of the supported API experience and should stay verified.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,13 +80,26 @@ the call site:
   release channel; this pinning style is explicitly recommended upstream.
 - Local composite actions (`uses: ./...`) — versioned with the repo.
 
-When adding a new external Action, run `git ls-remote <repo-url> <tag>`
-to resolve the SHA, then pin to the dereferenced commit
-(`<sha>^{}` form):
+When adding a new external Action, resolve the SHA with
+`git ls-remote <repo-url> 'refs/tags/<tag>^{}'`. The trailing `^{}`
+**dereferences** the ref to its target commit; without it, an
+*annotated* tag returns the tag-object SHA instead of the commit SHA,
+and the tag-object SHA is **not** a valid `uses:` target.
 
 ```bash
-git ls-remote https://github.com/actions/checkout refs/tags/v6
+# Annotated tag — the two forms return *different* SHAs:
+git ls-remote https://github.com/Azure/login 'refs/tags/v3.0.0' 'refs/tags/v3.0.0^{}'
+# 93381592...   refs/tags/v3.0.0       <- tag object, do NOT pin to this
+# 532459ea...   refs/tags/v3.0.0^{}    <- commit, pin to this one
+
+# Lightweight tag — only the non-deref form returns a row, and it is
+# already the commit SHA. Always include the `^{}` form anyway so the
+# same command works for both tag types:
+git ls-remote https://github.com/actions/setup-python 'refs/tags/v6' 'refs/tags/v6^{}'
 ```
+
+Single-quote the `refs/...^{}` argument so the `{}` and `^` are not
+interpreted by your shell (notably zsh with `EXTENDED_GLOB`).
 
 ## Example Coverage Policy
 


### PR DESCRIPTION
## Summary

- Pin every external GitHub Action `uses:` reference in `.github/workflows/` to a full 40-character commit SHA with a trailing `# vX.Y.Z` version comment.
- Document the policy and its single approved exception (`pypa/gh-action-pypi-publish@release/v1`) in `CONTRIBUTING.md` (new "GitHub Actions Pinning" subsection) and add a one-line pointer in `AGENTS.md`.
- After this change all **38** external `uses:` refs resolve to an immutable commit SHA; the single `release/v1` ref is the only documented exception and is flagged with an inline comment at the call site.

Closes #140.

## Why

Mutable version tags (including `@v6`, `@v6.0.1`, `@v3.0.0`) can be retroactively moved by an attacker who gains write access to the upstream Action repository. The [`tj-actions/changed-files` compromise (CVE-2025-30066, March 2025)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066) demonstrated this exact failure mode: ~23,000 repositories had their CI secrets exfiltrated, and only workflows that pinned to a commit SHA were safe.

- GitHub's own hardening guidance identifies SHA pinning as [the only way to use an Action as an immutable release](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).
- OpenSSF Scorecard's [`Pinned-Dependencies` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) flags anything weaker as Medium risk.
- Dependabot already runs weekly for `github-actions` in this repo (`.github/dependabot.yml`) and natively understands the `<sha> # vX.Y.Z` pattern — it bumps the SHA and keeps the trailing version comment in sync, so the human-readable context never drifts from the pinned commit.

## What changed

| File | Change |
|------|--------|
| `.github/workflows/ci-test.yml` | Add `# v6` / `# v6.0.1` to 6 already-SHA-pinned refs (checkout, setup-python, codecov-action). |
| `.github/workflows/db-integration.yml` | Pin 3 tag refs to SHAs: `actions/checkout@v6`, `actions/setup-python@v6`, `actions/upload-artifact@v7`. |
| `.github/workflows/docs.yml` | Add `# v6` to 2 already-SHA-pinned refs (checkout, setup-python). |
| `.github/workflows/e2e-azure.yml` | Pin 5 tag refs to SHAs: `actions/checkout@v6`, `azure/login@v3.0.0` (×2), `actions/setup-python@v6`, `actions/upload-artifact@v7`. |
| `.github/workflows/publish-pypi.yml` | Add inline exception comment beside `pypa/gh-action-pypi-publish@release/v1` so the rationale is visible at the call site. |
| `CONTRIBUTING.md` | Add "GitHub Actions Pinning" subsection (policy, rationale, exception list, lookup workflow). |
| `AGENTS.md` | Add one-line Working Rules pointer to the new section. |

Workflows already 100% compliant (no edits): `codeql.yml`, `create-release.yml`, `maintenance.yml`, `sbom.yml`, `security.yml`, `stale.yml`.

## Before / After audit

Total external `uses:` references (excluding documented exception): **38** in all cases.

| Repo state | SHA-pinned | Tag-pinned | Missing `# vX` comment |
|------------|-----------:|-----------:|-----------------------:|
| Before this PR | 27 | 11 | 8 |
| After this PR  | **38** | **0** | **0** |

Documented exception (1, unchanged): `pypa/gh-action-pypi-publish@release/v1` in `publish-pypi.yml`.

## SHA provenance

Every new SHA was resolved with `git ls-remote <upstream> refs/tags/<tag>` and matches an existing dereferenced commit on the upstream repository:

| Ref | SHA | Tag resolved via |
|-----|-----|------------------|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | Already in use across this repo as `# v6` |
| `actions/setup-python` | `a309ff8b426b58ec0e2a45f0f869d46889d02405` | Already in use across this repo as `# v6` |
| `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | Already in use in `sbom.yml` as `# v7.0.1` |
| `azure/login@v3.0.0` | `532459ea530d8321f2fb9bb10d1e0bcf23869a43` | `git ls-remote https://github.com/Azure/login refs/tags/v3.0.0` (dereferenced commit) |
| `codecov/codecov-action` | `e79a6962e0d4c0c17b229090214935d2e33f8354` | Already in use; verified as dereferenced commit of `refs/tags/v6.0.1` |

## Verification

- [x] `grep -rn 'uses:' .github/workflows/` shows exactly 38 SHA-pinned refs plus 1 documented `release/v1` exception.
- [x] All `azure/login@v3.0.0` references resolve to the same commit (`532459ea...`) and preserve the existing OIDC permissions block.
- [x] `actions/upload-artifact` is pinned to the same SHA already in use by `sbom.yml`, so no double-version drift exists across workflows.
- [x] `pypa/gh-action-pypi-publish@release/v1` is intentionally preserved per upstream guidance; CI alone cannot enforce this exception, so the rationale is committed inline beside the call site for future maintainers and automated agents.
- [x] `CONTRIBUTING.md` describes how to resolve a new SHA (`git ls-remote ... refs/tags/<tag>`) so future contributors do not need to ask.

## Out of scope (tracked separately if needed)

- Dependabot grouping (`groups:`) for `github-actions` — Oracle-approved deferral; per-PR review is currently preferred so each upstream SHA change can be inspected independently.
- Other sibling repositories (`scaffold`, `doctor`) — will be handled by their own issues (#114, #156) once this canary lands.