### PR TITLE
fix(writer): preserve original exception when rollback fails; raise WriteError for unsupported upsert dialect

### DIFF
--- a/src/azure_functions_db/binding/writer.py
+++ b/src/azure_functions_db/binding/writer.py
@@ -122,6 +122,12 @@ class DbWriter:
                 raise
             try:
                 tx.rollback()
+            except Exception:
+                logger.warning(
+                    "Failed to roll back transaction on exception;"
+                    " original exception will still be raised",
+                    exc_info=True,
+                )
             finally:
                 self._tx = None
                 self._tx_conn = None
@@ -503,7 +509,7 @@ class DbWriter:
             f"Upsert is not supported for dialect '{dialect}'. "
             f"Supported dialects: {sorted(_UPSERT_DIALECTS)}"
         )
-        raise ConfigurationError(msg)
+        raise WriteError(msg)
 
     def _build_pg_sqlite_upsert(
         self,

--- a/tests/integration/db/test_writer_live.py
+++ b/tests/integration/db/test_writer_live.py
@@ -9,7 +9,7 @@ from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine, 
 from sqlalchemy.engine import Engine
 
 from azure_functions_db.binding.writer import DbWriter
-from azure_functions_db.core.errors import ConfigurationError, WriteError
+from azure_functions_db.core.errors import WriteError
 
 
 def _db_param(db: str) -> object:

--- a/tests/integration/db/test_writer_live.py
+++ b/tests/integration/db/test_writer_live.py
@@ -254,10 +254,10 @@ def test_upsert_partial_columns(upsert_db: tuple[str, Engine, str]) -> None:
 
 @pytest.mark.integration
 @pytest.mark.mssql
-def test_upsert_mssql_raises_configuration_error(mssql_db: tuple[str, Engine]) -> None:
+def test_upsert_mssql_raises_write_error(mssql_db: tuple[str, Engine]) -> None:
     url, _engine = mssql_db
     with DbWriter(url=url, table="users") as writer:
-        with pytest.raises(ConfigurationError, match="Upsert is not supported for dialect 'mssql'"):
+        with pytest.raises(WriteError, match="Upsert is not supported for dialect 'mssql'"):
             writer.upsert(
                 data={"id": 1, "name": "Nope", "email": "nope@example.com"},
                 conflict_columns=["id"],

--- a/tests/test_binding_writer.py
+++ b/tests/test_binding_writer.py
@@ -530,7 +530,7 @@ class TestDbWriterErrorMapping:
             "name",
             "mssql",
         ):
-            with pytest.raises(ConfigurationError, match="not supported for dialect"):
+            with pytest.raises(WriteError, match="not supported for dialect"):
                 writer.upsert(
                     data={"id": 1, "name": "A"},
                     conflict_columns=["id"],

--- a/tests/test_binding_writer_transaction.py
+++ b/tests/test_binding_writer_transaction.py
@@ -70,6 +70,33 @@ class TestTransactionRollback:
                 writer.insert(data={"id": 1, "name": "Bob"})
         assert _row_count(users_url) == 0
 
+    def test_original_exception_preserved_when_rollback_fails(
+        self,
+        users_url: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Original exception must surface even when rollback() itself raises."""
+        import logging
+        from unittest.mock import MagicMock, patch
+
+        writer = DbWriter(url=users_url, table="users")
+        writer._ensure_initialized()
+
+        mock_tx = MagicMock()
+        mock_tx.rollback.side_effect = RuntimeError("rollback forced to fail")
+        mock_conn = MagicMock()
+        mock_conn.begin.return_value = mock_tx
+
+        with caplog.at_level(logging.WARNING, logger="azure_functions_db.binding.writer"):
+            with patch.object(writer._engine, "connect", return_value=mock_conn):
+                with pytest.raises(RuntimeError, match="the original error"):
+                    with writer.transaction():
+                        raise RuntimeError("the original error")
+
+        assert any(
+            "Failed to roll back transaction on exception" in r.message
+            for r in caplog.records
+        ), "Expected rollback-failure warning in log"
 
 class TestTransactionNesting:
     def test_nested_transaction_raises(self, users_url: str) -> None:


### PR DESCRIPTION
## Summary

- **Fix #153** – `tx.rollback()` in `transaction()` is now wrapped in `except Exception` so a rollback failure cannot swallow the original `BaseException`. Rollback failures are logged at `WARNING` level with `exc_info=True`.
- **Fix #158** – `_build_upsert_stmt()` now raises `WriteError` (not `ConfigurationError`) when the engine dialect is unsupported. Dialect is a runtime property, not a startup misconfiguration; callers catching `WriteError` should not miss this.

## Changes

| File | Change |
|---|---|
| `src/azure_functions_db/binding/writer.py` | Wrap rollback in `try/except Exception`; change `ConfigurationError` → `WriteError` for unknown dialect |
| `tests/test_binding_writer_transaction.py` | New test: original `RuntimeError` surfaces even when `rollback()` itself raises |
| `tests/test_binding_writer.py` | Update assertion from `ConfigurationError` to `WriteError` |

Closes #153
Closes #158