### PR TITLE
fix(trigger): emit debug log when cursor datetime is tz-naive and lag metric is skipped

### DIFF
--- a/src/azure_functions_db/trigger/runner.py
+++ b/src/azure_functions_db/trigger/runner.py
@@ -523,6 +523,14 @@ class PollRunner:
                                 (datetime.now(timezone.utc) - cursor_dt).total_seconds(),
                             )
                             emit_lag_metric(lag_seconds)
+                        else:
+                            logger.debug(
+                                "Poller '%s': cursor datetime '%s' is tz-naive;"
+                                " lag metric skipped. Use a tz-aware ISO timestamp"
+                                " (e.g. '…+00:00') to enable lag tracking.",
+                                self._name,
+                                cursor_for_lag,
+                            )
                     except (ValueError, TypeError):
                         pass
                 elif isinstance(cursor_for_lag, tuple) and cursor_for_lag:
@@ -536,6 +544,13 @@ class PollRunner:
                                     (datetime.now(timezone.utc) - cursor_dt).total_seconds(),
                                 )
                                 emit_lag_metric(lag_seconds)
+                            else:
+                                logger.debug(
+                                    "Poller '%s': cursor tuple[0] '%s' is"
+                                    " tz-naive; lag metric skipped.",
+                                    self._name,
+                                    first_part,
+                                )
                         except (ValueError, TypeError):
                             pass
 

--- a/tests/test_trigger_runner.py
+++ b/tests/test_trigger_runner.py
@@ -468,6 +468,29 @@ class TestPollRunner:
             name != METRIC_LAG_SECONDS for name, _, _ in metrics.gauges
         )  # noqa: S101
 
+    def test_lag_naive_datetime_emits_debug_log(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A tz-naive cursor string should produce a debug log, not silently vanish."""
+        naive_cursor = "2024-01-01T12:00:00"  # no tzinfo
+        records: list[RawRecord] = [{"id": 1, "updated_at": naive_cursor}]
+
+        runner = PollRunner(
+            name="naive_lag_poller",
+            source=FakeSourceAdapter(batches=[records]),
+            state_store=FakeStateStore(),
+            normalizer=_default_normalizer,
+            handler=lambda events: None,
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="azure_functions_db.trigger.runner"):
+            runner.tick()
+
+        assert any(
+            "tz-naive" in r.message and "naive_lag_poller" in r.message
+            for r in caplog.records
+        ), "Expected debug log about tz-naive cursor"
+
     def test_collector_exception_on_gauge_does_not_break_tick(self) -> None:
         lagging_cursor = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat()
         records: list[RawRecord] = [{"id": 1, "updated_at": lagging_cursor}]


### PR DESCRIPTION
## Summary

When the polled cursor is a tz-naive ISO datetime string (e.g. \`\"2024-01-01T12:00:00\"\`), the lag metric has always been silently skipped. Operators had no way to know lag tracking was inactive without noticing metric gaps.

This PR emits a `DEBUG`-level log message whenever a successfully-parsed cursor datetime has no `tzinfo`, naming the poller and the offending cursor value. Both the single-string cursor path and the `tuple[str, …]` cursor path are covered.

## Changes

| File | Change |
|---|---|
| `src/azure_functions_db/trigger/runner.py` | Add `else: logger.debug(...)` branch when `cursor_dt.tzinfo is None` |
| `tests/test_trigger_runner.py` | New test: tz-naive cursor emits expected debug log |

Closes #157