### PR TITLE
fix: emit UserWarning for no-params raw SQL queries and unimplemented RetryPolicy

### DIFF
--- a/src/azure_functions_db/binding/reader.py
+++ b/src/azure_functions_db/binding/reader.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from types import TracebackType
 from typing import Any
+import warnings
 
 from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.schema import Table
@@ -154,6 +155,14 @@ class DbReader:
         QueryError
             If the query execution fails.
         """
+        if params is None:
+            warnings.warn(
+                "query() called without params: verify that sql does not"
+                " concatenate user input. Use :name placeholders and pass"
+                " params=\"{'name': value}\" to prevent SQL injection.",
+                UserWarning,
+                stacklevel=2,
+            )
         self._ensure_initialized()
         assert self._engine is not None  # noqa: S101  # nosec B101
 
@@ -203,6 +212,14 @@ class DbReader:
         QueryError
             If the query execution fails or returns multiple rows.
         """
+        if params is None:
+            warnings.warn(
+                "scalar() called without params: verify that sql does not"
+                " concatenate user input. Use :name placeholders and pass"
+                " params=\"{'name': value}\" to prevent SQL injection.",
+                UserWarning,
+                stacklevel=2,
+            )
         self._ensure_initialized()
         assert self._engine is not None  # noqa: S101  # nosec B101
 

--- a/src/azure_functions_db/trigger/runner.py
+++ b/src/azure_functions_db/trigger/runner.py
@@ -8,6 +8,7 @@ import logging
 import time
 from typing import Any, Protocol, runtime_checkable
 import uuid
+import warnings
 
 from ..core.errors import CursorSerializationError
 from ..core.serializers import parse_checkpoint_cursor
@@ -123,6 +124,14 @@ class PollRunner:
         self._batch_size = batch_size
         self._max_batches_per_tick = max_batches_per_tick
         self._lease_ttl_seconds = lease_ttl_seconds
+        if retry_policy is not None:
+            warnings.warn(
+                "RetryPolicy is accepted but not yet applied in tick(). "
+                "The parameter is reserved for a future release and currently"
+                " has no effect on handler retry behaviour.",
+                UserWarning,
+                stacklevel=2,
+            )
         self._retry_policy = retry_policy or RetryPolicy()
         self._metrics = metrics or NoOpCollector()
         self._handler_arity = _detect_handler_arity(handler)

--- a/tests/test_binding_reader.py
+++ b/tests/test_binding_reader.py
@@ -300,6 +300,35 @@ class TestDbReaderQuery:
         assert cast(int, rows[0]["cnt"]) == 3
         reader.close()
 
+    def test_query_without_params_emits_user_warning(self, users_url: str) -> None:
+        reader = DbReader(url=users_url)
+        with pytest.warns(UserWarning, match="SQL injection"):
+            reader.query("SELECT 1")
+        reader.close()
+
+    def test_query_with_params_does_not_warn(self, users_url: str) -> None:
+        reader = DbReader(url=users_url)
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            # Supplying params must not trigger the injection warning.
+            reader.query("SELECT * FROM users WHERE id = :id", params={"id": 1})
+        reader.close()
+
+    def test_scalar_without_params_emits_user_warning(self, users_url: str) -> None:
+        reader = DbReader(url=users_url)
+        with pytest.warns(UserWarning, match="SQL injection"):
+            reader.scalar("SELECT COUNT(*) FROM users")
+        reader.close()
+
+    def test_scalar_with_params_does_not_warn(self, users_url: str) -> None:
+        reader = DbReader(url=users_url)
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            reader.scalar("SELECT * FROM users WHERE id = :id", params={"id": 1})
+        reader.close()
+
 
 class TestDbReaderLifecycle:
     def test_close_resets_state(self, users_url: str) -> None:

--- a/tests/test_trigger_runner.py
+++ b/tests/test_trigger_runner.py
@@ -166,6 +166,34 @@ class TestPollRunner:
 
         assert runner is not None  # noqa: S101
 
+    def test_retry_policy_emits_user_warning(self) -> None:
+        """Passing retry_policy must emit UserWarning since it has no effect yet."""
+        from azure_functions_db.trigger.retry import RetryPolicy
+
+        with pytest.warns(UserWarning, match="not yet applied"):
+            PollRunner(
+                name="retry_poller",
+                source=FakeSourceAdapter(batches=[]),
+                state_store=FakeStateStore(),
+                normalizer=_default_normalizer,
+                handler=lambda events: None,
+                retry_policy=RetryPolicy(max_retries=5),
+            )
+
+    def test_no_retry_policy_does_not_warn(self) -> None:
+        """Omitting retry_policy must not emit any warning."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            PollRunner(
+                name="no_retry_poller",
+                source=FakeSourceAdapter(batches=[]),
+                state_store=FakeStateStore(),
+                normalizer=_default_normalizer,
+                handler=lambda events: None,
+                # retry_policy defaults to None — no warning expected
+            )
     def test_default_metrics_is_noop(self) -> None:
         runner = PollRunner(
             name="test_poller",


### PR DESCRIPTION
## Summary

Addresses two \"false contract\" issues identified in the Oracle code review where the API silently accepted inputs that had no effect or carried hidden risks.

- **Fix #154** – `DbReader.query()` and `DbReader.scalar()` now emit `UserWarning` when `params is None`, prompting callers to verify they are not concatenating user input into the SQL string.
- **Fix #152** – `PollRunner.__init__` (and transitively `PollTrigger` and the decorator) emits `UserWarning` when a non-`None` `retry_policy` is passed, clearly stating the parameter is stored but not yet applied in `tick()`.

## Changes

| File | Change |
|---|---|
| `src/azure_functions_db/binding/reader.py` | `import warnings`; `warnings.warn(UserWarning)` in `query()` and `scalar()` when `params is None` |
| `src/azure_functions_db/trigger/runner.py` | `import warnings`; `warnings.warn(UserWarning)` in `PollRunner.__init__` when `retry_policy is not None` |
| `tests/test_binding_reader.py` | 4 new tests: warn with no params, no warn with params (both `query` and `scalar`) |
| `tests/test_trigger_runner.py` | 2 new tests: RetryPolicy warns; no warn when omitted |

Closes #152
Closes #154