### PR TITLE
fix(trigger): apply RetryPolicy in tick()

### DIFF
--- a/docs/03-semantics.md
+++ b/docs/03-semantics.md
@@ -137,9 +137,24 @@ Functions runtime retry and library-internal retry must not be confused.
 
 Principles:
 - DB fetch / retriable infrastructure errors: library-internal bounded retry is allowed
-- Handler business errors: surfaced as function failure
+- Handler business errors: **opt-in** in-tick retry via `RetryPolicy` (default: no retry, error is surfaced as function failure so Functions runtime / operators can react)
 - Checkpoint commit error: if commit fails, the batch remains unconfirmed
 
+### 8.1 Handler Retry (Opt-in)
+
+Callers may configure per-handler retry by passing a `RetryPolicy` to
+`PollTrigger`. When configured, `PollRunner.tick()` invokes the handler up to
+`max_retries + 1` times, sleeping `RetryPolicy.delay_for_attempt(attempt)`
+between attempts (exponential backoff, capped by `max_delay_seconds`).
+
+Semantics:
+- No `retry_policy` (default): the handler is invoked exactly once per tick. Any exception propagates and the batch is reprocessed on the next tick.
+- With `retry_policy`: retries occur **inside the current tick** while the poller holds its lease. Only after the final attempt fails does the batch surface as a handler failure and stay unacknowledged.
+- The checkpoint advances only when a handler attempt succeeds. Failed attempts do not advance the checkpoint, preserving at-least-once delivery.
+- Every retry emits a `handler_retry` structured log record with `attempt`, `max_attempts`, `delay_seconds`, and the exception type.
+- Retries always sleep synchronously via a swappable `_sleep` hook (defaults to `time.sleep`); tests inject a fake to run in virtual time.
+
+> **Retry vs. reprocessing:** In-tick retries occur within the current lease and do not re-read from the source. Cross-tick reprocessing (Case A / E / F in § 12) still applies when the tick ultimately fails or the process crashes.
 ## 9. Lease Semantics
 
 A lease is the "write authority for the current poller execution."

--- a/src/azure_functions_db/observability.py
+++ b/src/azure_functions_db/observability.py
@@ -70,6 +70,9 @@ def build_log_fields(
     lag_seconds: float | None = None,
     error_type: str | None = None,
     result: str | None = None,
+    attempt: int | None = None,
+    max_attempts: int | None = None,
+    delay_seconds: float | None = None,
 ) -> dict[str, object]:
     return {
         "event": event,
@@ -91,4 +94,7 @@ def build_log_fields(
         "lag_seconds": lag_seconds,
         "error_type": error_type,
         "result": result,
+        "attempt": attempt,
+        "max_attempts": max_attempts,
+        "delay_seconds": delay_seconds,
     }

--- a/src/azure_functions_db/trigger/runner.py
+++ b/src/azure_functions_db/trigger/runner.py
@@ -8,7 +8,6 @@ import logging
 import time
 from typing import Any, Protocol, runtime_checkable
 import uuid
-import warnings
 
 from ..core.errors import CursorSerializationError
 from ..core.serializers import parse_checkpoint_cursor
@@ -124,15 +123,8 @@ class PollRunner:
         self._batch_size = batch_size
         self._max_batches_per_tick = max_batches_per_tick
         self._lease_ttl_seconds = lease_ttl_seconds
-        if retry_policy is not None:
-            warnings.warn(
-                "RetryPolicy is accepted but not yet applied in tick(). "
-                "The parameter is reserved for a future release and currently"
-                " has no effect on handler retry behaviour.",
-                UserWarning,
-                stacklevel=2,
-            )
-        self._retry_policy = retry_policy or RetryPolicy()
+        self._retry_policy = retry_policy
+        self._sleep: Callable[[float], None] = time.sleep
         self._metrics = metrics or NoOpCollector()
         self._handler_arity = _detect_handler_arity(handler)
 
@@ -149,6 +141,63 @@ class PollRunner:
     @property
     def name(self) -> str:
         return self._name
+
+    def _invoke_handler_with_retry(
+        self,
+        events: list[RowChange],
+        context: PollContext,
+        *,
+        batch_id: str,
+        invocation_id: str,
+        source_name: str,
+    ) -> None:
+        """Invoke the handler, applying the retry policy on failure.
+
+        When no ``RetryPolicy`` is configured, the handler is invoked exactly
+        once and any exception propagates to the caller (preserving the
+        historical single-attempt behavior). When a policy is configured,
+        transient exceptions trigger up to ``max_retries`` additional attempts
+        with exponential backoff sourced from :meth:`RetryPolicy.delay_for_attempt`.
+        The final exception is re-raised once attempts are exhausted so the
+        outer batch loop can emit failure metrics and raise ``HandlerError``.
+        """
+        policy = self._retry_policy
+        max_attempts = 1 if policy is None else policy.max_retries + 1
+        for attempt in range(max_attempts):
+            try:
+                if self._handler_arity >= 2:  # noqa: PLR2004
+                    self._handler(events, context)
+                else:
+                    self._handler(events)
+                return
+            except Exception as exc:
+                remaining = max_attempts - attempt - 1
+                if remaining <= 0 or policy is None:
+                    raise
+                delay = policy.delay_for_attempt(attempt)
+                logger.warning(
+                    "Handler attempt %d/%d failed for poller '%s' batch '%s':"
+                    " %s; retrying in %.2fs",
+                    attempt + 1,
+                    max_attempts,
+                    self._name,
+                    batch_id,
+                    type(exc).__name__,
+                    delay,
+                    extra=build_log_fields(
+                        event="handler_retry",
+                        poller_name=self._name,
+                        invocation_id=invocation_id,
+                        batch_id=batch_id,
+                        source=source_name,
+                        attempt=attempt + 1,
+                        max_attempts=max_attempts,
+                        delay_seconds=delay,
+                        error_type=type(exc).__name__,
+                        result="retry",
+                    ),
+                )
+                self._sleep(delay)
 
     def tick(self) -> int:
         invocation_id = uuid.uuid4().hex
@@ -380,10 +429,13 @@ class PollRunner:
 
                 try:
                     handler_started_monotonic = time.monotonic()
-                    if self._handler_arity >= 2:  # noqa: PLR2004
-                        self._handler(events, context)
-                    else:
-                        self._handler(events)
+                    self._invoke_handler_with_retry(
+                        events,
+                        context,
+                        batch_id=batch_id,
+                        invocation_id=invocation_id,
+                        source_name=descriptor.name,
+                    )
                     handler_duration_ms = round(
                         (time.monotonic() - handler_started_monotonic) * 1000, 2
                     )

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -98,6 +98,9 @@ def test_build_log_fields_defaults() -> None:
         "lag_seconds": None,
         "error_type": None,
         "result": None,
+        "attempt": None,
+        "max_attempts": None,
+        "delay_seconds": None,
     }
 
 
@@ -122,6 +125,9 @@ def test_build_log_fields_all_fields() -> None:
         lag_seconds=30.0,
         error_type="ValueError",
         result="success",
+        attempt=1,
+        max_attempts=3,
+        delay_seconds=0.5,
     )
 
     assert fields["event"] == "batch_complete"  # noqa: S101
@@ -141,8 +147,10 @@ def test_build_log_fields_all_fields() -> None:
     assert fields["handler_duration_ms"] == 20.0  # noqa: S101
     assert fields["commit_duration_ms"] == 5.0  # noqa: S101
     assert fields["lag_seconds"] == 30.0  # noqa: S101
-    assert fields["error_type"] == "ValueError"  # noqa: S101
     assert fields["result"] == "success"  # noqa: S101
+    assert fields["attempt"] == 1  # noqa: S101, PLR2004
+    assert fields["max_attempts"] == 3  # noqa: S101, PLR2004
+    assert fields["delay_seconds"] == 0.5  # noqa: S101, PLR2004
 
 
 def test_custom_collector_satisfies_protocol() -> None:

--- a/tests/test_trigger_runner.py
+++ b/tests/test_trigger_runner.py
@@ -166,34 +166,253 @@ class TestPollRunner:
 
         assert runner is not None  # noqa: S101
 
-    def test_retry_policy_emits_user_warning(self) -> None:
-        """Passing retry_policy must emit UserWarning since it has no effect yet."""
+    def test_no_retry_policy_single_attempt(self) -> None:
+        """Without retry_policy, handler failure raises after a single attempt."""
+        records: list[RawRecord] = [{"id": 1, "updated_at": 100}]
+        source = FakeSourceAdapter(batches=[records])
+        store = FakeStateStore()
+        call_count = 0
+
+        def bad_handler(events: list[RowChange]) -> None:
+            nonlocal call_count
+            call_count += 1
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        runner = PollRunner(
+            name="no_retry_poller",
+            source=source,
+            state_store=store,
+            normalizer=_default_normalizer,
+            handler=bad_handler,
+        )
+
+        with pytest.raises(HandlerError):
+            runner.tick()
+        assert call_count == 1  # noqa: S101
+
+    def test_retry_policy_does_not_warn(self) -> None:
+        """Passing retry_policy must not emit UserWarning (it is now applied)."""
+        import warnings
+
         from azure_functions_db.trigger.retry import RetryPolicy
 
-        with pytest.warns(UserWarning, match="not yet applied"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
             PollRunner(
                 name="retry_poller",
                 source=FakeSourceAdapter(batches=[]),
                 state_store=FakeStateStore(),
                 normalizer=_default_normalizer,
                 handler=lambda events: None,
-                retry_policy=RetryPolicy(max_retries=5),
+                retry_policy=RetryPolicy(max_retries=3),
             )
 
-    def test_no_retry_policy_does_not_warn(self) -> None:
-        """Omitting retry_policy must not emit any warning."""
-        import warnings
+    def test_retry_policy_succeeds_first_attempt(self) -> None:
+        """Handler succeeds on first attempt: no retries, no sleeps."""
+        from azure_functions_db.trigger.retry import RetryPolicy
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
-            PollRunner(
-                name="no_retry_poller",
-                source=FakeSourceAdapter(batches=[]),
-                state_store=FakeStateStore(),
-                normalizer=_default_normalizer,
-                handler=lambda events: None,
-                # retry_policy defaults to None — no warning expected
-            )
+        records: list[RawRecord] = [{"id": 1, "updated_at": 100}]
+        source = FakeSourceAdapter(batches=[records])
+        store = FakeStateStore()
+        call_count = 0
+
+        def handler(events: list[RowChange]) -> None:
+            nonlocal call_count
+            call_count += 1
+
+        runner = PollRunner(
+            name="retry_ok_poller",
+            source=source,
+            state_store=store,
+            normalizer=_default_normalizer,
+            handler=handler,
+            retry_policy=RetryPolicy(max_retries=3, base_delay_seconds=0.01),
+        )
+        sleeps: list[float] = []
+        runner._sleep = sleeps.append  # noqa: SLF001
+
+        runner.tick()
+        assert call_count == 1  # noqa: S101
+        assert sleeps == []  # noqa: S101
+
+    def test_retry_policy_recovers_from_transient_failure(self) -> None:
+        """Handler fails then succeeds: retries invoked, checkpoint advances."""
+        from azure_functions_db.trigger.retry import RetryPolicy
+
+        records: list[RawRecord] = [{"id": 1, "updated_at": 100}]
+        source = FakeSourceAdapter(batches=[records])
+        store = FakeStateStore()
+        call_count = 0
+
+        def flaky_handler(events: list[RowChange]) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:  # noqa: PLR2004
+                msg = "transient"
+                raise RuntimeError(msg)
+
+        runner = PollRunner(
+            name="flaky_poller",
+            source=source,
+            state_store=store,
+            normalizer=_default_normalizer,
+            handler=flaky_handler,
+            retry_policy=RetryPolicy(max_retries=3, base_delay_seconds=0.01),
+        )
+        sleeps: list[float] = []
+        runner._sleep = sleeps.append  # noqa: SLF001
+
+        runner.tick()
+        assert call_count == 3  # noqa: S101,PLR2004
+        assert len(sleeps) == 2  # noqa: S101,PLR2004
+        assert "flaky_poller" in store.checkpoints  # noqa: S101
+
+    def test_retry_policy_exhaustion_raises_handler_error(self) -> None:
+        """Handler always fails: max_retries+1 attempts total, then HandlerError."""
+        from azure_functions_db.trigger.retry import RetryPolicy
+
+        records: list[RawRecord] = [{"id": 1, "updated_at": 100}]
+        source = FakeSourceAdapter(batches=[records])
+        store = FakeStateStore()
+        call_count = 0
+
+        def bad_handler(events: list[RowChange]) -> None:
+            nonlocal call_count
+            call_count += 1
+            msg = "perma-fail"
+            raise RuntimeError(msg)
+
+        runner = PollRunner(
+            name="exhausted_poller",
+            source=source,
+            state_store=store,
+            normalizer=_default_normalizer,
+            handler=bad_handler,
+            retry_policy=RetryPolicy(max_retries=2, base_delay_seconds=0.01),
+        )
+        sleeps: list[float] = []
+        runner._sleep = sleeps.append  # noqa: SLF001
+
+        with pytest.raises(HandlerError):
+            runner.tick()
+        assert call_count == 3  # 1 initial + 2 retries  # noqa: S101,PLR2004
+        assert len(sleeps) == 2  # sleep only between retries  # noqa: S101,PLR2004
+        assert "exhausted_poller" not in store.checkpoints  # noqa: S101
+
+    def test_retry_policy_uses_exponential_backoff(self) -> None:
+        """Sleep delays follow RetryPolicy.delay_for_attempt()."""
+        from azure_functions_db.trigger.retry import RetryPolicy
+
+        records: list[RawRecord] = [{"id": 1, "updated_at": 100}]
+        source = FakeSourceAdapter(batches=[records])
+        store = FakeStateStore()
+
+        def bad_handler(events: list[RowChange]) -> None:
+            msg = "fail"
+            raise RuntimeError(msg)
+
+        policy = RetryPolicy(
+            max_retries=3,
+            base_delay_seconds=0.5,
+            exponential_base=2.0,
+            max_delay_seconds=60.0,
+        )
+        runner = PollRunner(
+            name="backoff_poller",
+            source=source,
+            state_store=store,
+            normalizer=_default_normalizer,
+            handler=bad_handler,
+            retry_policy=policy,
+        )
+        sleeps: list[float] = []
+        runner._sleep = sleeps.append  # noqa: SLF001
+
+        with pytest.raises(HandlerError):
+            runner.tick()
+        # delay_for_attempt(0)=0.5, (1)=1.0, (2)=2.0
+        assert sleeps == [
+            pytest.approx(0.5),
+            pytest.approx(1.0),
+            pytest.approx(2.0),
+        ]  # noqa: S101
+
+    def test_retry_policy_respects_max_delay_cap(self) -> None:
+        """delay_for_attempt is clamped to max_delay_seconds."""
+        from azure_functions_db.trigger.retry import RetryPolicy
+
+        records: list[RawRecord] = [{"id": 1, "updated_at": 100}]
+        source = FakeSourceAdapter(batches=[records])
+        store = FakeStateStore()
+
+        def bad_handler(events: list[RowChange]) -> None:
+            msg = "fail"
+            raise RuntimeError(msg)
+
+        policy = RetryPolicy(
+            max_retries=4,
+            base_delay_seconds=10.0,
+            exponential_base=10.0,
+            max_delay_seconds=15.0,
+        )
+        runner = PollRunner(
+            name="cap_poller",
+            source=source,
+            state_store=store,
+            normalizer=_default_normalizer,
+            handler=bad_handler,
+            retry_policy=policy,
+        )
+        sleeps: list[float] = []
+        runner._sleep = sleeps.append  # noqa: SLF001
+
+        with pytest.raises(HandlerError):
+            runner.tick()
+        # 10.0, 100.0->15, 1000.0->15, 10000.0->15
+        assert sleeps == [
+            pytest.approx(10.0),
+            pytest.approx(15.0),
+            pytest.approx(15.0),
+            pytest.approx(15.0),
+        ]  # noqa: S101
+
+    def test_retry_policy_logs_each_retry_attempt(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Each retry emits a warning log with attempt number and delay."""
+        from azure_functions_db.trigger.retry import RetryPolicy
+
+        records: list[RawRecord] = [{"id": 1, "updated_at": 100}]
+        source = FakeSourceAdapter(batches=[records])
+        store = FakeStateStore()
+
+        def bad_handler(events: list[RowChange]) -> None:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        runner = PollRunner(
+            name="logged_poller",
+            source=source,
+            state_store=store,
+            normalizer=_default_normalizer,
+            handler=bad_handler,
+            retry_policy=RetryPolicy(max_retries=2, base_delay_seconds=0.01),
+        )
+        runner._sleep = lambda _s: None  # noqa: SLF001
+
+        with caplog.at_level(
+            logging.WARNING, logger="azure_functions_db.trigger.runner"
+        ), pytest.raises(HandlerError):
+            runner.tick()
+
+        retry_records = [
+            r for r in caplog.records if r.getMessage().startswith("Handler attempt")
+        ]
+        assert len(retry_records) == 2  # noqa: S101,PLR2004
+        assert getattr(retry_records[0], "attempt", None) == 1  # noqa: S101
+        assert getattr(retry_records[1], "attempt", None) == 2  # noqa: S101,PLR2004
+
     def test_default_metrics_is_noop(self) -> None:
         runner = PollRunner(
             name="test_poller",


### PR DESCRIPTION
Closes #171

## Priority: P1

## Context
`RetryPolicy` has been advertised on `PollTrigger` (and stored on
`PollRunner`) for several releases, but `tick()` never actually consulted
it. The constructor emitted a `UserWarning` acknowledging the no-op,
and handler exceptions surfaced immediately with the configured backoff
never applied. This PR wires the retry loop, drops the warning, and
documents the resulting contract.

## What Changed

### Runtime (`src/azure_functions_db/trigger/runner.py`)
- `_retry_policy` is now **optional**:
  - `None` (default) → single attempt; historical semantics preserved.
  - `RetryPolicy(...)` → bounded in-tick retry with exponential backoff.
- New `_invoke_handler_with_retry()` helper wraps the handler call:
  - Attempts capped at `max_retries + 1`
  - Backoff delay from `RetryPolicy.delay_for_attempt(attempt)`
  - `log.warning` per retry with attempt/max/delay extras
  - Re-raises the final exception so the outer batch loop keeps its
    existing `HandlerError` wrapping and metric emission behaviour.
- New `_sleep` instance attribute (defaults to `time.sleep`) so tests
  can substitute a virtual-time sleeper.
- Removed the `warnings` import and the constructor `UserWarning`.

### Observability (`src/azure_functions_db/observability.py`)
- `build_log_fields()` gained kw-only `attempt`, `max_attempts`,
  `delay_seconds`. Internal helper (not in `__all__`); defaults keep
  existing callers source-compatible.

### Docs (`docs/03-semantics.md` §8)
- Documents the opt-in retry contract, its checkpoint-preservation
  behaviour, structured logging, and interaction with cross-tick
  reprocessing (Cases A / E / F in §12).

## Tests
- Removed `test_retry_policy_emits_user_warning` /
  `test_no_retry_policy_does_not_warn` (the warning is gone).
- Added 8 positive tests in `tests/test_trigger_runner.py`:
  1. No-policy single attempt still raises `HandlerError`.
  2. `RetryPolicy` no longer emits `UserWarning`.
  3. Success on first attempt → no sleeps.
  4. Transient failures recover, checkpoint advances, sleeps observed.
  5. Exhaustion raises `HandlerError`, checkpoint does **not** advance.
  6. Exponential backoff delays match `delay_for_attempt`.
  7. `max_delay_seconds` cap clamps large exponents.
  8. Retry emits structured log records with `.attempt` extra.
- Updated `test_build_log_fields_defaults` and `_all_fields` for the
  new keys.

## Validation
- `make test` → **605 passed / 88 skipped**
- `make lint` → clean (64 source files)
- `make typecheck` → clean (64 source files)
- `make build` → wheel + sdist built
- Coverage → **95%** total; uncovered lines in `runner.py` are the
  pre-existing tz-naive cursor-lag branches (595-616, 673-674), not
  the new retry path.

## Acceptance Checklist
- [x] `tick()` invokes the handler with `RetryPolicy`-driven bounded retry.
- [x] Retries respect `max_retries`, `base_delay_seconds`, `max_delay_seconds`, `exponential_base`.
- [x] Checkpoint only advances on a successful handler attempt.
- [x] Retries are logged with structured fields.
- [x] Constructor `UserWarning` removed.
- [x] Docs §8 documents the opt-in contract.
- [x] Coverage >= 95%.

## Out of Scope
- Retryable-vs-fatal exception taxonomy (all exceptions are currently
  retried until the budget is exhausted).
- Dead-letter queue / quarantine sink (Case I remains manual).
- Distributed coordination changes (lease semantics unchanged).

## References
- Issue #171