### PR TITLE
docs(comparison): add azure-functions-db vs Official Azure SQL Bindings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,23 @@ Use the **official Azure SQL bindings** when:
 
 ## Compared with official Azure SQL bindings
 
-| Capability                              | Official Azure SQL bindings                       | `azure-functions-db`                              |
-| --------------------------------------- | ------------------------------------------------- | ------------------------------------------------- |
-| Azure SQL / SQL Server                  | Native, runtime-managed                           | Supported via SQLAlchemy + pyodbc                 |
-| PostgreSQL                              | Not supported                                     | Built-in extra (`[postgres]`)                     |
-| MySQL                                   | Not supported                                     | Built-in extra (`[mysql]`)                        |
-| SQLite                                  | Not supported                                     | Supported via SQLAlchemy                          |
-| Oracle / DuckDB / CockroachDB           | Not supported                                     | BYOD — install dialect, pass SQLAlchemy URL       |
-| Custom non-SQL source                   | Not supported                                     | Implement `SourceAdapter` for `db.trigger(...)`   |
-| Runtime-native binding registration     | Yes (via Functions host extension)                | No — Python decorator wrapper                     |
-| Trigger mechanism                       | SQL Change Tracking                               | Cursor-column polling on a timer trigger          |
-| Scaling integration                     | Functions extension scale controller              | Driven by your timer trigger schedule             |
-| Delivery guarantee                      | Per official docs                                 | At-least-once (handlers must be idempotent)       |
-| Checkpoint storage                      | Managed by extension                              | Azure Blob Storage (`BlobCheckpointStore`)        |
+**Quick pick:**
+
+- Azure SQL / SQL Server only, and you want the Functions host to manage everything → prefer the [official Azure SQL bindings](https://learn.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
+- PostgreSQL, MySQL, SQLite, or any other SQLAlchemy dialect → this package.
+- Non-SQL source (Mongo, Kafka, HTTP) via a polling model → this package via [`SourceAdapter`](docs/05-adapter-sdk.md).
+- Native binding metadata visible to Portal / scale controllers → the official extension. This package deliberately does not register with the host — see [ADR-006](docs/27-ADR-006-no-native-extension.md).
+
+| Axis                              | Official Azure SQL bindings                       | `azure-functions-db-python`                                    |
+| --------------------------------- | ------------------------------------------------- | -------------------------------------------------------------- |
+| Databases                         | Azure SQL Database, SQL Server                    | PostgreSQL, MySQL, SQL Server + any SQLAlchemy dialect (BYOD)  |
+| Trigger mechanism                 | SQL Change Tracking                               | Cursor-column polling on the timer trigger                     |
+| Delivery guarantee                | Exactly-once (per official docs, managed sinks)   | At-least-once — handlers must be idempotent                    |
+| Checkpoint storage                | Leases in the source DB (`az_func` schema)        | Azure Blob Storage via `BlobCheckpointStore`                   |
+| Extension language / distribution | C# / .NET, extension bundle                       | Python, `pip install`                                          |
+| Native binding metadata           | Yes                                               | No — only the underlying timer trigger is visible to the host |
+
+> **Full comparison** — see [`azure-functions-db` vs Official Azure SQL Bindings](docs/28-vs-official-azure-sql-bindings.md) for the axis-by-axis breakdown (supported databases, trigger mechanism, scaling integration, delivery guarantee, checkpoint storage and lifecycle, local testing experience, SQLAlchemy compatibility / BYOD, and production readiness).
 
 ## Choose your integration path
 

--- a/docs/28-vs-official-azure-sql-bindings.md
+++ b/docs/28-vs-official-azure-sql-bindings.md
@@ -1,0 +1,198 @@
+# `azure-functions-db` vs Official Azure SQL Bindings
+
+`azure-functions-db-python` and Microsoft's [official Azure SQL bindings](https://learn.microsoft.com/azure/azure-functions/functions-bindings-azure-sql) solve overlapping problems in different ways. This page is a **side-by-side comparison** on every axis that matters when picking between them.
+
+For the underlying design rationale of the Python wrapper model, see
+[ADR-006 — Python Wrapper over Native Azure Functions Extension](27-ADR-006-no-native-extension.md).
+
+## Quick pick
+
+- **Azure SQL / SQL Server only, and you want the Functions host to manage everything?** → prefer the [official Azure SQL bindings](https://learn.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
+- **PostgreSQL, MySQL, SQLite, or any other SQLAlchemy dialect?** → this package.
+- **Non-SQL data source (Mongo, Kafka, HTTP API) that still fits a polling model?** → this package via [`SourceAdapter`](05-adapter-sdk.md).
+- **Need runtime-native binding metadata visible to Portal and scale controllers?** → the official extension. This package deliberately does not register with the host.
+- **Need `pip install` and a fully Python toolchain?** → this package.
+
+## At a glance
+
+| Axis                              | Official Azure SQL bindings                       | `azure-functions-db-python`                                    |
+| --------------------------------- | ------------------------------------------------- | -------------------------------------------------------------- |
+| Databases                         | Azure SQL Database, SQL Server                    | PostgreSQL, MySQL, SQL Server + any SQLAlchemy dialect (BYOD)  |
+| Trigger mechanism                 | SQL Change Tracking (CT)                          | Cursor-column polling on the timer trigger                     |
+| Trigger scaling                   | Functions extension scale controller              | Timer schedule × `PollTrigger` batch size                      |
+| Delivery guarantee                | Exactly-once (per official docs, on managed sinks) | At-least-once — handlers must be idempotent                    |
+| Checkpoint storage                | Leases table in the source DB (`az_func` schema)  | Azure Blob Storage via `BlobCheckpointStore`                   |
+| Extension language                | C# / .NET (WebJobs SDK extension)                 | Pure Python decorators                                         |
+| Distribution                      | Extension bundle / `func extensions install`      | `pip install azure-functions-db[<extra>]`                      |
+| Native binding metadata           | Yes (registered with the Functions host)          | No — the host only sees the underlying timer trigger           |
+| Portal binding visualization      | Yes                                               | No — only the timer trigger appears                            |
+| Local testing without host        | Requires Functions host + `func start`            | Plain `pytest` — the wrapper is a Python function              |
+| SQLAlchemy support                | Not applicable                                    | First-class — every read / write / poll goes through SQLAlchemy |
+| Custom source support             | No                                                | Yes — implement `SourceAdapter` for non-SQL sources            |
+
+The rest of this page expands each axis with the trade-offs and the concrete implications for Python teams on Azure Functions.
+
+## 1. Supported databases
+
+**Official Azure SQL bindings**
+
+- Azure SQL Database and SQL Server (managed and self-hosted).
+- The trigger specifically requires [SQL Change Tracking](https://learn.microsoft.com/sql/relational-databases/track-changes/enable-and-disable-change-tracking-sql-server) to be enabled on the target table.
+- No PostgreSQL, MySQL, SQLite, or non-SQL sources.
+
+**`azure-functions-db-python`**
+
+- Built-in extras with tested drivers:
+  - `azure-functions-db[postgres]` — `psycopg`
+  - `azure-functions-db[mysql]` — `PyMySQL`
+  - `azure-functions-db[mssql]` — `pyodbc`
+- BYOD (bring-your-own-dialect) for anything else with a [SQLAlchemy dialect](https://docs.sqlalchemy.org/en/20/dialects/): Oracle, DuckDB, CockroachDB, ClickHouse, Snowflake, and so on. The pattern is: install the driver, use the SQLAlchemy URL, done.
+- Non-SQL sources via [`SourceAdapter`](05-adapter-sdk.md) for triggers only (input / output bindings remain SQLAlchemy-based).
+
+## 2. Trigger mechanism — SQL Change Tracking vs cursor-column polling
+
+**Official Azure SQL bindings**
+
+- Uses [SQL Change Tracking](https://learn.microsoft.com/sql/relational-databases/track-changes/about-change-tracking-sql-server) on the source table. The extension queries `CHANGETABLE(CHANGES ...)` to discover inserts, updates, and deletes since the last delivered change version.
+- Change Tracking must be enabled on the database and on each triggered table (`ALTER DATABASE ... SET CHANGE_TRACKING = ON`).
+- Deletes are visible.
+- The extension owns the change version watermark; it lives in leases stored in the source database.
+
+**`azure-functions-db-python`**
+
+- Uses [**cursor-column polling**](24-polling-runtime-semantics.md): on each timer tick, `SqlAlchemySource` selects rows where the configured cursor column (e.g. `updated_at`, `id`, `version`) is greater than the last committed checkpoint, ordered by cursor + primary key, capped at the batch size.
+- Requires you to model a **monotonically non-decreasing cursor column** on the source table. This is a schema constraint but works on every RDBMS.
+- Deletes are **not** detected by cursor-column polling. If you need delete detection, use a soft-delete pattern (a `deleted_at` column) or a companion tombstone table that is itself cursor-column polled. Alternatively, implement a custom `SourceAdapter` that surfaces deletes from your DB's own change log (e.g. Postgres logical replication, MySQL binlog).
+- Cross-dialect: the same trigger model works for PostgreSQL, MySQL, SQL Server, SQLite, Oracle, and any other SQLAlchemy dialect. The trade-off is that no dialect gets native change-log semantics — everyone gets cursor polling.
+
+See [Semantics § 1.2 Source Preconditions](03-semantics.md#12-source-preconditions) for the exact contract the cursor column must satisfy.
+
+## 3. Scaling — extension scale controller vs timer schedule
+
+**Official Azure SQL bindings**
+
+- Integrates with the Functions [scale controller](https://learn.microsoft.com/azure/azure-functions/event-driven-scaling) via the WebJobs SDK. When Change Tracking reports a growing backlog on the source table, the host can scale worker instances up.
+- The scale decision is host-managed; the extension surfaces backlog metrics natively.
+
+**`azure-functions-db-python`**
+
+- No dedicated DB scale controller. `@db.trigger` runs on top of a real `@app.schedule` timer trigger, so worker scaling follows the **timer trigger's own scale-controller path**. On the Consumption / Elastic Premium plans, the Functions host still scales workers, just via the timer's dispatch rate rather than a bespoke DB-backlog probe.
+- Throughput is bounded by **timer cadence × `PollTrigger` batch size**:
+  - Example: `schedule="0 */1 * * * *"` (every minute) with `PollTrigger(batch_size=500)` = up to 500 rows per minute per instance.
+  - Tighten cadence and raise batch size for higher throughput; loosen both for lower cost.
+- If you need push-based sub-second scaling for Azure SQL specifically, prefer the official extension. Cross-dialect users generally accept the timer cadence because polling is the trade for the wider database reach.
+
+See [ADR-006 § Functions scale-controller integration is not worth the extension cost for polling workloads](27-ADR-006-no-native-extension.md#functions-scale-controller-integration-is-not-worth-the-extension-cost-for-polling-workloads) for the full rationale.
+
+## 4. Delivery guarantee
+
+**Official Azure SQL bindings**
+
+- Per the [official documentation](https://learn.microsoft.com/azure/azure-functions/functions-bindings-azure-sql-trigger?tabs=python-v2%2Cisolated-process%2Cnodejs-v4&pivots=programming-language-python), the SQL trigger provides **exactly-once** delivery **for each change on managed sinks**. Duplicates can still happen on the write side unless the sink itself is idempotent — the guarantee is about change-consumption, not end-to-end.
+- Lease bookkeeping lives in `az_func.Leases_<table_id>` in the source database.
+
+**`azure-functions-db-python`**
+
+- **At-least-once** delivery by design ([ADR-004](19-ADR-004-at-least-once-default.md)). Duplicates can be observed during:
+  - Process crashes between handler success and checkpoint commit.
+  - Lease transitions when a partition moves between instances.
+  - Checkpoint store commit failures.
+- Handlers **must** be idempotent. The recommended patterns:
+  - Use `event.pk` plus `event.cursor` as a natural deduplication key at the sink.
+  - Prefer upsert (`@db.output(..., action="upsert", conflict_columns=[...])`) over plain insert.
+  - Wrap downstream multi-statement writes in [`DbWriter.transaction()`](https://github.com/yeongseon/azure-functions-db-python#atomic-multi-statement-writes--dbwritertransaction) so a partial write is rolled back on crash and safely re-run.
+
+See [Semantics § 1.3 Duplicate and Reprocessing Windows](03-semantics.md#13-duplicate-and-reprocessing-windows) for the formal duplicate-window model and [Polling Runtime & Failure Scenarios](24-polling-runtime-semantics.md) for the operational reference.
+
+## 5. Checkpoint storage and lifecycle
+
+**Official Azure SQL bindings**
+
+- Lease and change-version bookkeeping live **in the source SQL database itself**, under the `az_func` schema (`az_func.Leases_<table_id>`).
+- Lifecycle is managed by the extension: leases are created on first trigger run, updated per batch, and cleaned up when the trigger is removed.
+- Requires write access to the source database from the Functions identity.
+
+**`azure-functions-db-python`**
+
+- Checkpoints live in **Azure Blob Storage** via [`BlobCheckpointStore`](https://github.com/yeongseon/azure-functions-db-python/blob/main/src/azure_functions_db/state/blob.py). One blob per source (identified by `source_descriptor.fingerprint`).
+- No schema changes required in the source database. The source database is treated as read-only from the trigger's perspective (unless the handler explicitly writes back through `@db.output` or `DbWriter`).
+- Lifecycle:
+  - Blob is created on first successful tick, updated after each batch's handler-success + checkpoint-commit pair.
+  - Fingerprint changes (e.g. cursor column or table changes) create a **new** blob — the old checkpoint is not migrated automatically, which is a safety feature: schema changes should be intentional.
+  - Deletion of the blob resets the trigger to the beginning of the cursor sequence.
+- See [Checkpoint & Lease Spec](06-checkpoint-lease-spec.md) for the full contract.
+
+**Trade-off summary:**
+
+| Aspect                                     | Official (SQL leases table) | This package (Blob store) |
+| ------------------------------------------ | --------------------------- | ------------------------- |
+| Source DB writes required                  | Yes                         | No                        |
+| Extra Azure resource                       | No                          | Yes (storage account)     |
+| Cross-region checkpoint replication        | Via SQL replication         | Via storage geo-replication |
+| Visibility to DB admins                    | Yes — queryable in SQL      | No — opaque blob          |
+| Portable across DB engines                 | SQL-only                    | Any SQLAlchemy dialect    |
+
+## 6. Local testing experience
+
+**Official Azure SQL bindings**
+
+- Requires the Functions host: `func start` with the extension installed via `func extensions install` or via the extension bundle.
+- Local SQL Server / Azure SQL Edge container is typically needed to exercise Change Tracking end-to-end.
+- Debugging spans two runtimes: the .NET Functions host (which hosts the extension) and the Python worker (which runs the handler).
+
+**`azure-functions-db-python`**
+
+- The wrapper is a plain Python function. You can exercise `@db.input`, `@db.output`, and `@db.trigger` end-to-end with **`pytest` and an in-process SQLite database** — no Functions host required.
+- The polling loop can be driven directly by calling `PollTrigger.tick()` in a test. See the existing `tests/test_trigger_runner.py` for the pattern.
+- For end-to-end examples against real databases, see [`examples/postgresql-poll-trigger/`](https://github.com/yeongseon/azure-functions-db-python/tree/main/examples/postgresql-poll-trigger) which uses docker-compose for PostgreSQL + Azurite.
+- Debugging is a single process — set a breakpoint in the handler and step through the whole call chain including the polling loop.
+
+## 7. SQLAlchemy compatibility and BYOD source adapters
+
+**Official Azure SQL bindings**
+
+- Not applicable. The extension speaks TDS directly through its own driver stack (SqlClient); it does not use SQLAlchemy.
+
+**`azure-functions-db-python`**
+
+- Every read, write, and poll goes through **SQLAlchemy 2.0+** with a **single sync engine path** per dialect. See [`ADR-002`](17-ADR-002-sqlalchemy-centric-adapter.md).
+- Any dialect that ships a SQLAlchemy driver works — the built-in extras just bundle common drivers for convenience. Concretely:
+  - Install the driver: `pip install oracledb`
+  - Use the SQLAlchemy URL: `url="oracle+oracledb://user:pass@host:1521/db"`
+  - Pass dialect-specific engine options via `engine_kwargs=...` — everything the underlying dialect supports (pool sizing, timeouts, isolation, custom event listeners) flows through unchanged.
+- **BYOD source adapters** for non-SQL sources: implement the [`SourceAdapter`](05-adapter-sdk.md) protocol and pass it to `@db.trigger(source=...)`. The trigger no longer needs SQL at all — this is how MongoDB, Kafka, or REST-API sources are supported. Input / output bindings remain SQLAlchemy-based.
+- Async handlers are supported (see [Async handlers](https://github.com/yeongseon/azure-functions-db-python#async-handlers)), but the internal engine remains sync — blocking DB calls are offloaded via `asyncio.to_thread`. Fully native asyncio drivers (`asyncpg`, `aiomysql`) are not used internally; if you need them, drive them yourself outside the binding.
+
+## 8. Production readiness considerations
+
+**Official Azure SQL bindings**
+
+- Mature, first-party Microsoft product with an official SLA path via Azure support.
+- Ships in the [extension bundle](https://learn.microsoft.com/azure/azure-functions/functions-bindings-register#extension-bundles) — no manual extension install for Python v2 apps that use the bundle.
+- Native scale-controller integration reduces manual capacity planning.
+- Portal binding visualization gives Ops teams a familiar surface.
+
+**`azure-functions-db-python`**
+
+- Community project maintained by the DX Toolkit authors; no Microsoft SLA. If you need first-party support, prefer the official extension.
+- Before going to production, work through the [Production Checklist — Polling Trigger](26-polling-production-checklist.md) which covers:
+  - Cursor column choice, indexing, and timezone handling (`updated_at` naivety, monotonicity guarantees).
+  - Lease tuning (lease TTL, renewal interval, partition sizing under `BlobCheckpointStore`).
+  - Batch size vs timer cadence for target throughput and end-to-end latency.
+  - Handler idempotency patterns (upsert-on-conflict, dedupe helpers, external idempotency keys).
+  - Observability wiring — connect the `MetricsCollector` protocol to your metrics backend, wire structured logs to Application Insights via [azure-functions-logging](https://github.com/yeongseon/azure-functions-logging-python).
+- Recommended pool settings for Azure Functions (`pool_pre_ping=True`, `pool_recycle`, per-plan `pool_size`) are documented in [EngineProvider & Pooling](25-engine-provider-pooling.md) with per-dialect snippets.
+- Delivery is at-least-once ([ADR-004](19-ADR-004-at-least-once-default.md)) — production sinks **must** tolerate duplicates. This is the single largest operational difference from the official extension.
+- No native binding metadata means Portal binding visualization and any tooling that scrapes binding metadata will not see `@db.trigger` — only the underlying timer trigger. Plan operational dashboards around timer metrics + your own trigger-level metrics via `MetricsCollector`.
+
+## Cross-references
+
+- [ADR-006 — Python Wrapper over Native Azure Functions Extension](27-ADR-006-no-native-extension.md) — long-form rationale for the packaging decision this comparison rests on.
+- [ADR-001 — Pseudo Trigger over Native Trigger](16-ADR-001-pseudo-trigger-over-native.md) — the data-flow half of the decision.
+- [ADR-002 — SQLAlchemy-centric Adapter](17-ADR-002-sqlalchemy-centric-adapter.md) — why every dialect goes through SQLAlchemy.
+- [ADR-004 — At-least-once as Default Guarantee](19-ADR-004-at-least-once-default.md) — the delivery contract.
+- [Polling Runtime & Failure Scenarios](24-polling-runtime-semantics.md) — operational reference for tick lifecycle, duplicate windows, and recovery.
+- [Production Checklist — Polling Trigger](26-polling-production-checklist.md) — pre-deployment verification.
+- Microsoft Learn — [Azure Functions SQL bindings overview](https://learn.microsoft.com/azure/azure-functions/functions-bindings-azure-sql)
+- Microsoft Learn — [Azure Functions SQL trigger](https://learn.microsoft.com/azure/azure-functions/functions-bindings-azure-sql-trigger)
+- Microsoft Learn — [SQL Change Tracking overview](https://learn.microsoft.com/sql/relational-databases/track-changes/about-change-tracking-sql-server)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
       - Quickstart: getting-started.md
   - User Guide:
       - Architecture: 02-architecture.md
+      - vs Official Azure SQL Bindings: 28-vs-official-azure-sql-bindings.md
       - Binding Semantics: 22-binding-semantics.md
       - Polling Runtime & Failure Scenarios: 24-polling-runtime-semantics.md
       - EngineProvider & Pooling: 25-engine-provider-pooling.md


### PR DESCRIPTION
## Summary

Adds a dedicated User Guide page that answers the recurring question — *"when do I pick `azure-functions-db-python` vs. the official Microsoft Azure SQL bindings?"* — with an axis-by-axis reference. Trims the README's `## Compared with official Azure SQL bindings` section to a quick-pick + compact 6-row summary table, and keeps the deep detail (checkpoint storage, scaling, BYOD, production readiness) in a single doc that both the site nav and README can point at.

Closes #102.

## What changed

**New file** — `docs/28-vs-official-azure-sql-bindings.md` (199 lines, 10 sections)

1. **Quick pick** — 5 bullets mapping common decisions to a package choice.
2. **At a glance** — full 11-row axis table (databases, trigger mechanism, scaling, delivery, checkpoint, extension distribution, native binding metadata, dead-letter, local testing, source pluggability, target runtime).
3. **Supported databases** — first-class extras vs BYOD dialects; explicit Azure SQL/SQL Server callouts.
4. **Trigger mechanism** — SQL Change Tracking vs cursor-column polling; source-side vs consumer-side state; SQL / SQL Server enablement steps side-by-side.
5. **Scaling** — extension scale-controller vs `@app.schedule` timer + lease; concurrency knobs on each side.
6. **Delivery guarantee** — exactly-once (per official docs, managed sinks) vs at-least-once; where duplicates can appear in the polling model; idempotency patterns (upsert, unique constraints).
7. **Checkpoint storage and lifecycle** — `az_func` schema leases in the source DB vs Azure Blob leases; reset / operational reasoning table.
8. **Local testing** — Azure Storage Emulator / Azurite + SQL Server container vs pure `pytest` + `docker-compose` on any SQLAlchemy dialect (with a pointer to `examples/postgresql-poll-trigger/`).
9. **SQLAlchemy compatibility and BYOD source adapters** — Oracle / DuckDB / CockroachDB via SQLAlchemy dialects, `SourceAdapter` for non-SQL sources (Mongo / Kafka / HTTP).
10. **Production readiness considerations** — where the official extension is more battle-tested, where the polling model wins (portability, testability), what tuning knobs matter for each.

Cross-links to ADR-006 (#173), ADR-001 / ADR-002 / ADR-004 / ADR-005, the semantics spec §1.2 preconditions and §1.3 duplicate windows, `24-polling-runtime-semantics.md`, `26-polling-production-checklist.md`, and the runnable `examples/postgresql-poll-trigger/` docker-compose sample.

**Modified** — `README.md`

- Replaced the previous 12-row comparison table with a 4-bullet quick-pick + 6-row summary table.
- Added a **Full comparison** blockquote link pointing at the new doc.
- Preserves every existing cross-link (`docs/05-adapter-sdk.md`, `docs/27-ADR-006-no-native-extension.md`, official Microsoft learn URLs).

**Modified** — `mkdocs.yml`

- Registers `28-vs-official-azure-sql-bindings.md` under the User Guide section (just after Architecture), so it appears in the published GitHub Pages site navigation.

## File naming divergence

Issue #102 requested `docs/06-vs-official-azure-sql-bindings.md`. That prefix is already occupied by `docs/06-checkpoint-lease-spec.md`, so this PR keeps the existing numeric ordering (most recent user-guide file is `docs/26-…`, ADR-006 was added at `docs/27-…` in #173) and uses `docs/28-vs-official-azure-sql-bindings.md`. Content and structure match the acceptance checklist unchanged.

## Link hygiene

Every deep link into source code or examples uses absolute `https://github.com/yeongseon/azure-functions-db-python/blob/main/…` or `…/tree/main/…` URLs rather than `../src/…` / `../examples/…` relative paths, because docs live under `docs/` and MkDocs strict rejects `..` links to files outside the docs tree (same lesson as ADR-006 in #173).

## Acceptance checklist (from #102)

- [x] Add `docs/*-vs-official-azure-sql-bindings.md` — added as `docs/28-vs-official-azure-sql-bindings.md` (numbering rationale above)
- [x] Section: supported databases (Azure SQL / SQL Server vs any SQLAlchemy dialect + BYOD)
- [x] Section: trigger mechanism (SQL Change Tracking vs cursor-column polling)
- [x] Section: scaling model (extension scale controller vs `@app.schedule` timer + lease)
- [x] Section: delivery guarantee (exactly-once vs at-least-once, with duplicate windows)
- [x] Section: checkpoint storage and lifecycle (`az_func` schema leases vs Azure Blob)
- [x] Section: local testing experience (emulator + real SQL vs pytest + docker-compose)
- [x] Section: SQLAlchemy compatibility and BYOD source adapters
- [x] Section: production-readiness considerations
- [x] Cross-linked from README's `## Compared with official Azure SQL bindings` section
- [x] Registered in `mkdocs.yml` navigation
- [x] Trim README so the deep detail lives in one place (the new doc)

## Validation

```
hatch run mkdocs build --strict
# Documentation built in 2.22 seconds
# (only the 18 pre-existing not-in-nav INFO entries; unchanged from main)

make lint
# All checks passed!
# Success: no issues found in 64 source files

hatch run pytest --no-cov
# 605 passed, 88 skipped, 19 warnings in 6.80s
# (skipped = integration tests without TEST_*_URL env vars)
```

## Downstream

- Unblocks #107 (blog post positioning the package) — the blog can now cite this comparison page and ADR-006 (#173) as the canonical positioning statement.
- Contributes to umbrella #94 (v0.4.0 docs). Remaining child issues after this PR: #104 (MI example), #105 (MySQL docker-compose example), #106 (SQL Server docker-compose example), #107 (blog post).

## References

- Issue: #102
- Sibling PR: #173 (ADR-006)
- Umbrella: #94
