### PR TITLE
docs(examples): add MySQL polling-trigger docker-compose example

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -78,4 +78,4 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq shellcheck
-          shellcheck examples/postgresql-poll-trigger/smoke.sh
+          shellcheck examples/postgresql-poll-trigger/smoke.sh examples/mysql-poll-trigger/smoke.sh

--- a/examples/mysql-poll-trigger/README.md
+++ b/examples/mysql-poll-trigger/README.md
@@ -1,0 +1,348 @@
+# MySQL polling-trigger example
+
+End-to-end runnable example for `azure-functions-db`'s poll-based pseudo
+trigger against MySQL 8.0, with checkpoints stored in
+[Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite)
+(the local Azure Storage emulator).
+
+The example polls an `orders` table on a one-minute timer, treats each row
+change as an event, and writes an idempotent projection into a
+`processed_orders` table on every tick.
+
+> Delivery is **at-least-once**. Handlers in this example are intentionally
+> idempotent — see the inline comments in `function_app.py` and the
+> [Polling Runtime & Failure Scenarios](../../docs/24-polling-runtime-semantics.md)
+> page for the full duplicate-window reference.
+
+> Companion to the [`postgresql-poll-trigger`](../postgresql-poll-trigger/)
+> example. The two share the same structure, so if you already know that
+> example the only differences here are MySQL-specific — see
+> [MySQL-specific gotchas](#mysql-specific-gotchas) below.
+
+---
+
+## What you get
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` | MySQL 8.0 + Azurite for the checkpoint store |
+| `schema.sql` | `orders` source table (with a monotonic `updated_at` cursor maintained by `ON UPDATE CURRENT_TIMESTAMP(6)`), plus `processed_orders` projection |
+| `function_app.py` | A timer-driven `@db.trigger` polling `orders`, writing into `processed_orders` via `@db.output` |
+| `host.json` | Functions host config |
+| `local.settings.json.example` | All required environment variables |
+| `requirements.txt` | Function App dependencies |
+| `smoke.sh` | Self-contained end-to-end smoke test (no `func` CLI required) |
+
+---
+
+## Prerequisites
+
+- Docker + Docker Compose v2
+- Python 3.10+
+- [Azure Functions Core Tools v4](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
+  (`func` CLI)
+- `mysql` client for seeding rows (`apt-get install mysql-client` or the
+  `mysql-client` package for your distro)
+
+---
+
+## End-to-end run
+
+> **Verify your environment first**: run [`./smoke.sh`](smoke.sh) to bring
+> up MySQL + Azurite, apply the schema, drive a single poll tick from
+> Python, and assert the projection table received the expected rows. The
+> script is self-contained (no `func` CLI required) and exits non-zero on
+> any failure. Use it as a smoke test in CI or as a sanity check before
+> running the full Functions host below.
+
+### 1. Start MySQL and Azurite
+
+```bash
+cd examples/mysql-poll-trigger
+docker compose up -d
+```
+
+This brings up:
+
+- `mysql` on `localhost:3306` (user `app`, password `app`, database `app`, root password `root`)
+- `azurite` on `localhost:10000` (Blob), `10001` (Queue), `10002` (Table)
+
+Wait until both containers report healthy (MySQL takes ~15–30 s on first
+boot while it initialises the data directory and creates the `app`
+user):
+
+```bash
+docker compose ps
+```
+
+### 2. Initialise the schema
+
+```bash
+MYSQL_PWD=app mysql -h 127.0.0.1 -P 3306 -u app app < schema.sql
+```
+
+You should see no output on success (`mysql` is quiet on success by
+default). Verify:
+
+```bash
+MYSQL_PWD=app mysql -h 127.0.0.1 -P 3306 -u app app -e "SHOW TABLES;"
+```
+
+should list `orders` and `processed_orders`.
+
+### 3. Configure local settings
+
+```bash
+cp local.settings.json.example local.settings.json
+```
+
+The defaults already point at the docker-compose services and Azurite — no
+edits are needed for the happy-path local run.
+
+### 4. Install dependencies
+
+```bash
+python -m venv .venv
+source .venv/bin/activate     # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+### 5. Run the Function App
+
+```bash
+func start
+```
+
+You should see `orders_poll` registered as a Timer trigger firing every
+minute.
+
+### 6. Insert / update rows in `orders`
+
+In another terminal:
+
+```bash
+MYSQL_PWD=app mysql -h 127.0.0.1 -P 3306 -u app app <<'SQL'
+-- Let AUTO_INCREMENT allocate the ids; inserting explicit values does
+-- not advance the counter and would collide with later auto-id inserts.
+INSERT INTO orders (customer_name, amount, status)
+VALUES ('Alice', 99.99, 'pending'),
+       ('Bob',   49.50, 'pending');
+
+-- Wait for the next tick, then update one row to see another event.
+-- Identifying by customer_name keeps this snippet runnable without
+-- knowing the assigned ids.
+UPDATE orders SET status = 'shipped', amount = 109.99
+ WHERE customer_name = 'Alice';
+SQL
+```
+
+### 7. Observe events
+
+In the `func start` log you should see structured log entries like:
+
+```text
+Poller 'orders' batch <id>: processed 2 events
+```
+
+Verify the projection table:
+
+```bash
+MYSQL_PWD=app mysql -h 127.0.0.1 -P 3306 -u app app -e \
+  "SELECT order_id, source_cursor, customer_name, amount, status \
+     FROM processed_orders ORDER BY order_id, source_cursor;"
+```
+
+You should see one row per delivered event — the initial insert produces
+one row, and the subsequent `UPDATE` produces another row with the same
+`order_id` but a later `source_cursor`. This is the strictly-idempotent
+projection pattern: replays of the same `RowChange` collide on
+`(order_id, source_cursor)` and are no-op upserts.
+
+Verify the checkpoint blob:
+
+```bash
+docker exec -it $(docker compose ps -q azurite) sh -c \
+  "ls -la /data/__blobstorage__ 2>/dev/null || true"
+```
+
+(or use Azure Storage Explorer pointed at `UseDevelopmentStorage=true`).
+
+### 8. Tear down
+
+```bash
+docker compose down -v   # -v also removes the mysql + azurite volumes
+```
+
+---
+
+## Cursor column choice
+
+The example uses `updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)`
+as the cursor column. This satisfies the framework's source
+preconditions:
+
+- **Monotonically non-decreasing** — the server bumps `updated_at` to
+  `CURRENT_TIMESTAMP(6)` on every INSERT and every UPDATE via the
+  `ON UPDATE` column attribute. **No application-level trigger is
+  required** — this is one of the small ergonomic wins MySQL has over
+  the PostgreSQL example.
+- **Stable PK / total ordering** — `(updated_at, id)` is unique enough for
+  ordered batching (the framework appends `id` as the tiebreaker via
+  `pk_columns=["id"]`).
+- **Deterministic** — the source query is a plain
+  `SELECT ... ORDER BY updated_at, id` with a `(updated_at, id)` cursor
+  filter; no application-level non-determinism.
+
+> If your real schema uses `created_at` only and rows are mutated in place,
+> you will silently miss updates. Always pick a column that is updated on
+> **every** mutation you care about, or use a soft-delete / outbox pattern.
+> See [Semantics §4 — Delete Semantics](../../docs/03-semantics.md#4-delete-semantics).
+
+## Idempotent handler pattern
+
+`function_app.py` writes to `processed_orders` with `action="upsert"`
+and `conflict_columns=["order_id", "source_cursor"]`. On MySQL the
+framework rewrites this to
+`INSERT INTO processed_orders (...) VALUES (...) ON DUPLICATE KEY UPDATE col = VALUES(col)`
+under the hood (see
+[`_build_mysql_upsert`](https://github.com/yeongseon/azure-functions-db-python/blob/main/src/azure_functions_db/binding/writer.py)).
+Because the polling trigger is at-least-once, the same `RowChange` may be
+redelivered during commit failures, lease transitions, or process crashes
+(see [§4 Duplicate Window Reference](../../docs/24-polling-runtime-semantics.md#4-duplicate-window-reference)).
+The composite key `(event.pk, event.cursor)` ensures the replay collides
+on the exact same row with byte-identical column values, so the second
+write is a true no-op.
+
+### When latest-state projection is what you want
+
+If you only need the *current* state per `order_id` (last write wins),
+key on `order_id` alone — e.g. drop `source_cursor` from the primary key
+and from `conflict_columns`. That's a simpler, smaller table, but be
+aware that:
+
+- An out-of-order replay of an older event can overwrite a newer
+  projection.
+- "Replay = no-op" only holds when the replay carries the same column
+  values as the previous delivery; for true event-level dedup, prefer
+  the composite-key pattern above.
+
+### When upsert is not available
+
+If your sink does not natively support upsert, swap the `@db.output`
+for an `inject_writer`-based handler that maintains a
+`processed_events` table keyed by `(event.pk, event.cursor)` with a
+unique constraint, and swallow the unique-violation on replay. On MySQL
+you can equivalently write `INSERT IGNORE INTO processed_events ...`,
+which silently swallows duplicate-key errors on the primary key —
+smoke.sh uses exactly this pattern.
+
+## Checkpoint container configuration
+
+`function_app.py` builds a `BlobCheckpointStore` against the container
+`db-state` in the storage account named by `AzureWebJobsStorage`. The
+container is created on first use by Azurite. In production, create it
+explicitly with the minimal RBAC needed (Storage Blob Data Contributor on
+that container only) — see
+[Checkpoint / Lease Spec §12](../../docs/06-checkpoint-lease-spec.md#12-operational-guidelines).
+
+## MySQL-specific gotchas
+
+MySQL has several dialect and driver quirks that matter for polling. The
+example is set up to avoid all of them; this section explains why so you
+know what to preserve in your own deployment.
+
+### 1. Timezone handling — always run the server on UTC
+
+MySQL's `DATETIME` type is **timezone-naive**: it stores exactly what you
+write and returns exactly what was stored, with no conversion. `TIMESTAMP`
+is stored as UTC but converted on read using the *session* time zone,
+which is a footgun for a monotonic cursor — two workers with different
+session TZs would see different values and the cursor comparison would
+become non-deterministic.
+
+The example avoids this by:
+
+- Using `DATETIME(6)` (not `TIMESTAMP`) for `updated_at`, `source_cursor`,
+  `processed_at`.
+- Starting the server with `--default-time-zone=+00:00` in
+  `docker-compose.yml` so `CURRENT_TIMESTAMP(6)` always returns UTC.
+- Setting the container env `TZ=UTC` for completeness.
+
+In production, either mirror those flags in your MySQL configuration
+(`my.cnf`: `default-time-zone = +00:00`) or make sure your application
+always writes UTC values explicitly.
+
+### 2. `ON UPDATE CURRENT_TIMESTAMP` replaces the PostgreSQL trigger
+
+MySQL's `DATETIME DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)`
+does what the PostgreSQL `BEFORE INSERT OR UPDATE` trigger does in the
+sibling example. This is a one-liner in the column definition — no
+stored function, no trigger. Prefer it.
+
+### 3. Upsert syntax
+
+The framework's `action="upsert"` compiles to
+`INSERT ... ON DUPLICATE KEY UPDATE col = VALUES(col)` on MySQL — see
+`_build_mysql_upsert` in the writer implementation. The conflict target
+must be a UNIQUE index or PRIMARY KEY on the columns you list in
+`conflict_columns`; the example uses the composite PRIMARY KEY
+`(order_id, source_cursor)`.
+
+> **Note:** MySQL 8.0.20 deprecates the `VALUES(col)` form in favour of
+> row-aliased syntax (`INSERT ... AS new ON DUPLICATE KEY UPDATE col = new.col`).
+> The SQLAlchemy MySQL dialect this package uses generates the
+> `VALUES(col)` form, which still works and is not going away — but if
+> you inspect the raw SQL, that's what you'll see.
+
+### 4. Character set / collation
+
+Use `utf8mb4` / `utf8mb4_0900_ai_ci` (the MySQL 8 default), not the
+legacy `utf8` alias which is 3-byte-only and cannot round-trip 4-byte
+UTF-8 characters (most emoji, some CJK). All tables in `schema.sql`
+declare this explicitly.
+
+### 5. Driver choice — PyMySQL vs mysqlclient
+
+The `[mysql]` extra pulls in [PyMySQL](https://pymysql.readthedocs.io/)
+(`pymysql>=1.1`), a pure-Python driver. It is the default because it
+installs without a C build step and works out of the box on every Python
+version supported by the package (3.10 – 3.14).
+
+If you need native throughput (2×–5× on tight workloads), install
+[mysqlclient](https://github.com/PyMySQL/mysqlclient) separately and
+switch the URL prefix from `mysql+pymysql://` to `mysql+mysqldb://`.
+mysqlclient is a compiled C driver and needs a MySQL client library
+(`libmysqlclient-dev` on Debian/Ubuntu, `mysql-devel` on RHEL) and a C
+toolchain to install.
+
+PyMySQL 1.1+ supports MySQL 8's default `caching_sha2_password`
+authentication plugin, so the example does not force
+`mysql_native_password` on the server.
+
+### 6. `TRUNCATE` cannot list multiple tables
+
+Unlike PostgreSQL, MySQL's `TRUNCATE` accepts exactly one table per
+statement. Both the schema reset in `smoke.sh` and any manual cleanup
+must run two separate statements
+(`TRUNCATE TABLE orders; TRUNCATE TABLE processed_orders;`). `TRUNCATE`
+also resets `AUTO_INCREMENT` to `1` automatically — no `RESTART
+IDENTITY` clause needed.
+
+## Tuning notes
+
+The example uses the package defaults — `batch_size=100`,
+`max_batches_per_tick=1`, `lease_ttl_seconds=120`, timer schedule
+`0 */1 * * * *` (every minute). For production sizing rules and the
+`lease_ttl_seconds` vs handler-duration relationship see
+[Polling Runtime §7](../../docs/24-polling-runtime-semantics.md#7-tuning-lease_ttl_seconds-and-timer-interval).
+
+For MySQL pool settings (`pool_pre_ping`, `pool_recycle`, `max_overflow`,
+`connect_timeout`), see
+[EngineProvider & Pooling §5](../../docs/25-engine-provider-pooling.md).
+Two knobs matter more on MySQL than PostgreSQL:
+
+- **`pool_recycle`** — set below MySQL's `wait_timeout` (default 28 800 s
+  / 8 h). Azure Database for MySQL Flexible Server defaults to lower
+  values; check yours and set `pool_recycle` to about half of it.
+- **`connect_args={"connect_timeout": ...}`** — PyMySQL's default
+  `connect_timeout` is 10 s. Raise it for cross-region deployments.

--- a/examples/mysql-poll-trigger/docker-compose.yml
+++ b/examples/mysql-poll-trigger/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: afdb-mysql
+    # `--default-time-zone=+00:00` is required — see schema.sql for the
+    # rationale. Without it, DATETIME(6) values written by CURRENT_TIMESTAMP(6)
+    # would follow the container's local time zone and the cursor comparison
+    # the framework does on `updated_at` would become non-deterministic.
+    command:
+      - --default-time-zone=+00:00
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: app
+      MYSQL_USER: app
+      MYSQL_PASSWORD: app
+      TZ: UTC
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysqldata:/var/lib/mysql
+    healthcheck:
+      # `mysqladmin ping` returns success as soon as the server is accepting
+      # TCP connections, so we also authenticate as the app user to make sure
+      # `MYSQL_DATABASE` / `MYSQL_USER` init has finished before dependent
+      # steps run (`docker compose up --wait` blocks on this).
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "app", "--password=app"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:latest
+    container_name: afdb-mysql-azurite
+    command: >
+      azurite
+      --blobHost 0.0.0.0
+      --queueHost 0.0.0.0
+      --tableHost 0.0.0.0
+      --location /data
+      --skipApiVersionCheck
+    ports:
+      - "10000:10000"   # Blob
+      - "10001:10001"   # Queue
+      - "10002:10002"   # Table
+    volumes:
+      - azurite-data:/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - 'node -e "require(''net'').createConnection(10000, ''127.0.0.1'').on(''connect'', () => process.exit(0)).on(''error'', () => process.exit(1))"'
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  mysqldata:
+  azurite-data:

--- a/examples/mysql-poll-trigger/function_app.py
+++ b/examples/mysql-poll-trigger/function_app.py
@@ -1,0 +1,168 @@
+"""MySQL polling-trigger example.
+
+This Function App polls a MySQL ``orders`` table every minute via
+``@db.trigger`` and writes a strictly-idempotent event projection into
+``processed_orders`` via ``@db.output``.
+
+Required environment variables (see local.settings.json.example):
+
+- AzureWebJobsStorage  Connection string for the checkpoint blob container.
+                       Defaults to Azurite (``UseDevelopmentStorage=true``).
+- SOURCE_DB_URL        SQLAlchemy URL for the source database (the table
+                       the trigger polls).
+- DEST_DB_URL          SQLAlchemy URL for the destination database. May be
+                       the same database; the bindings share an
+                       ``EngineProvider`` so the connection pool is reused.
+
+Delivery is at-least-once. The handler is intentionally idempotent: it
+upserts on the composite key ``(order_id, source_cursor)`` — which the
+framework rewrites to MySQL's ``INSERT ... ON DUPLICATE KEY UPDATE`` —
+so a replay during a commit failure, lease transition, or process crash
+collides on the exact same key and becomes a no-op write of identical
+data.
+
+Why a composite key? A single ``order_id`` PK would be a *latest-state
+projection* — replays still land in the same row, but a delayed replay of
+an older event could overwrite a newer projection. Keying on
+``(event.pk, event.cursor)`` instead makes "redelivery = byte-identical
+no-op" precisely true and is the canonical dedup pattern for this
+package.
+
+MySQL-specific notes (see README.md for the full rationale):
+
+    * ``updated_at`` is a plain ``DATETIME(6)`` column with
+      ``DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)`` in
+      the schema — no application-level trigger is needed to maintain the
+      cursor. The server bumps it on every INSERT and UPDATE.
+    * ``event.cursor[0]`` is a timezone-naive ``datetime.datetime`` (MySQL
+      DATETIME has no time-zone metadata). The container is started with
+      ``--default-time-zone=+00:00`` so the naive value represents UTC.
+    * The SqlAlchemySource omits ``schema=`` because in MySQL the database
+      name in the URL already scopes the table; MySQL does not have a
+      separate "schema" namespace within a database.
+
+See:
+    docs/24-polling-runtime-semantics.md  for the operational reference.
+    docs/25-engine-provider-pooling.md    for pool tuning.
+"""
+
+from __future__ import annotations
+
+import os
+
+import azure.functions as func
+from azure.storage.blob import ContainerClient
+
+from azure_functions_db import (
+    BlobCheckpointStore,
+    DbBindings,
+    DbOut,
+    EngineProvider,
+    RowChange,
+    SqlAlchemySource,
+)
+
+app = func.FunctionApp()
+db = DbBindings()
+
+# Module-level EngineProvider so the source and the output binding share
+# a single SQLAlchemy engine (and therefore a single connection pool) per
+# worker process.  See docs/25-engine-provider-pooling.md.
+engine_provider = EngineProvider()
+
+# The source query is `SELECT ... FROM orders ORDER BY updated_at, id`
+# filtered by the last committed (cursor, pk) checkpoint.  ``updated_at``
+# is a MySQL DATETIME(6) column with `ON UPDATE CURRENT_TIMESTAMP(6)`, so
+# the server maintains it monotonically on every mutation — no
+# application-level trigger required (unlike the PostgreSQL example).
+source = SqlAlchemySource(
+    url="%SOURCE_DB_URL%",
+    table="orders",
+    # `schema=` intentionally omitted: MySQL uses the database name in the
+    # URL as the effective schema; a separate `schema` argument would be
+    # rejected by MySQL as an invalid qualified name.
+    cursor_column="updated_at",
+    pk_columns=["id"],
+    engine_provider=engine_provider,
+)
+
+# Checkpoint and lease are stored as a single JSON blob in the ``db-state``
+# container.  Azurite creates the container on first use; in production,
+# pre-create it and grant the Function App identity Storage Blob Data
+# Contributor scoped to that container only.
+#
+# NOTE: ``%VAR%`` placeholder syntax is an Azure Functions binding-layer
+# feature that this package resolves for its own ``url=...`` arguments.
+# The Azure Storage SDK does *not* perform that substitution, so we read
+# the connection string from the process environment directly here.
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str=os.environ["AzureWebJobsStorage"],
+        container_name="db-state",
+    ),
+    source_fingerprint=source.source_descriptor.fingerprint,
+)
+
+
+@app.function_name(name="orders_poll")
+@app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
+@db.trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+@db.output(
+    "out",
+    url="%DEST_DB_URL%",
+    table="processed_orders",
+    # On MySQL the framework rewrites `action="upsert"` to
+    # `INSERT ... ON DUPLICATE KEY UPDATE col=VALUES(col)` under the hood
+    # (see azure_functions_db.binding.writer._build_mysql_upsert). The
+    # unique index is the PRIMARY KEY (order_id, source_cursor).
+    action="upsert",
+    conflict_columns=["order_id", "source_cursor"],
+    engine_provider=engine_provider,
+)
+def orders_poll(
+    timer: func.TimerRequest,
+    events: list[RowChange],
+    out: DbOut,
+) -> None:
+    """Project ``orders`` row changes into ``processed_orders``.
+
+    Every projection row is keyed by ``(order_id, source_cursor)`` —
+    i.e. ``(event.pk["id"], event.cursor[0])``. A replay of the same
+    ``RowChange`` produces an upsert against the same composite key with
+    identical column values, so the second write is a true no-op.
+
+    For a *latest-state* projection (one row per ``order_id``, last
+    write wins) you would instead key on ``order_id`` alone — but be
+    aware that out-of-order replays could then overwrite a newer state
+    with an older one. See docs/24-polling-runtime-semantics.md §9.
+    """
+    del timer
+
+    if not events:
+        return
+
+    # `event.cursor` is a tuple aligned with the source's
+    # `(cursor_column, *pk_columns)` ordering — here `(updated_at, id)`.
+    # The first element is the source-side change timestamp
+    # (DATETIME(6), timezone-naive UTC because the container runs with
+    # `--default-time-zone=+00:00`); we persist that as `source_cursor`.
+    # `processed_at` records when *we* observed the event, so it is
+    # wall-clock `now()`, not the source cursor.
+    from datetime import datetime, timezone
+
+    processed_at = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    out.set(
+        [
+            {
+                "order_id": event.pk["id"],
+                "source_cursor": event.cursor[0],
+                "customer_name": event.after["customer_name"],
+                "amount": event.after["amount"],
+                "status": event.after["status"],
+                "processed_at": processed_at,
+            }
+            for event in events
+            if event.after is not None
+        ]
+    )

--- a/examples/mysql-poll-trigger/host.json
+++ b/examples/mysql-poll-trigger/host.json
@@ -1,0 +1,11 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  }
+}

--- a/examples/mysql-poll-trigger/local.settings.json.example
+++ b/examples/mysql-poll-trigger/local.settings.json.example
@@ -1,0 +1,9 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "SOURCE_DB_URL": "mysql+pymysql://app:app@localhost:3306/app",
+    "DEST_DB_URL": "mysql+pymysql://app:app@localhost:3306/app"
+  }
+}

--- a/examples/mysql-poll-trigger/requirements.txt
+++ b/examples/mysql-poll-trigger/requirements.txt
@@ -1,0 +1,2 @@
+azure-functions
+azure-functions-db[mysql]

--- a/examples/mysql-poll-trigger/schema.sql
+++ b/examples/mysql-poll-trigger/schema.sql
@@ -1,0 +1,46 @@
+-- Source table polled by the @db.trigger.
+--
+-- The cursor column is `updated_at`. MySQL supports
+-- `DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)` directly
+-- on DATETIME columns, so unlike the PostgreSQL example we do **not** need
+-- a `BEFORE INSERT OR UPDATE` trigger to maintain it — the server does it
+-- for us on every INSERT and every UPDATE.
+--
+-- We use DATETIME(6) (microsecond precision) rather than TIMESTAMP:
+--   * TIMESTAMP is stored as UTC but converted on read using the session
+--     time zone, which introduces non-determinism into the cursor
+--     comparison the framework relies on.
+--   * DATETIME is timezone-naive and returns exactly what was written, so
+--     if the server always writes UTC (see `--default-time-zone=+00:00`
+--     in docker-compose.yml) the cursor is monotonically non-decreasing
+--     in real wall-clock UTC.
+--
+-- utf8mb4 / utf8mb4_0900_ai_ci is the MySQL 8 default and safely handles
+-- 4-byte UTF-8 (unlike the legacy `utf8` alias, which is 3-byte only).
+CREATE TABLE IF NOT EXISTS orders (
+    id            BIGINT         NOT NULL AUTO_INCREMENT,
+    customer_name VARCHAR(255)   NOT NULL,
+    amount        DECIMAL(12, 2) NOT NULL,
+    status        VARCHAR(32)    NOT NULL DEFAULT 'pending',
+    created_at    DATETIME(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at    DATETIME(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+                                          ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    KEY orders_updated_at_id_idx (updated_at, id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Strictly-idempotent destination table.
+-- The composite primary key (order_id, source_cursor) ensures that a
+-- replay of the same RowChange (at-least-once delivery) collides on the
+-- exact same row and is a no-op upsert. Keying on order_id alone would
+-- be a latest-state projection: replays still hit the same row, but an
+-- out-of-order replay of an older event could overwrite a newer state.
+CREATE TABLE IF NOT EXISTS processed_orders (
+    order_id      BIGINT         NOT NULL,
+    source_cursor DATETIME(6)    NOT NULL,
+    customer_name VARCHAR(255)   NOT NULL,
+    amount        DECIMAL(12, 2) NOT NULL,
+    status        VARCHAR(32)    NOT NULL,
+    processed_at  DATETIME(6)    NOT NULL,
+    PRIMARY KEY (order_id, source_cursor)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/examples/mysql-poll-trigger/smoke.sh
+++ b/examples/mysql-poll-trigger/smoke.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# End-to-end smoke test for the MySQL polling-trigger example.
+#
+# Brings up MySQL + Azurite via docker compose, applies the schema,
+# inserts and updates a row, and verifies that the package's polling
+# logic produces the expected projection. Does NOT run `func start`
+# (that requires the Azure Functions Core Tools and a long-lived
+# process); instead it drives a single poll tick from Python so the
+# script stays self-contained and CI-friendly.
+#
+# Requires Docker Compose v2 (`docker compose ...`, not `docker-compose`)
+# because we rely on `--format json` and `up --wait`.
+#
+# Exits non-zero on any failure with a message identifying the step.
+# Always tears down docker resources and the temporary venv on exit,
+# even if a step fails.
+
+set -euo pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly EXAMPLE_DIR
+readonly MYSQL_URL="mysql+pymysql://app:app@127.0.0.1:3306/app"
+readonly AZURITE_CONN_STR="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;TableEndpoint=http://localhost:10002/devstoreaccount1;"
+readonly CONTAINER_NAME="db-state"
+
+log() { printf '\n[smoke] %s\n' "$*"; }
+fail() { printf '\n[smoke][FAIL] %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+    local rc=$?
+    log "cleanup (exit=${rc})"
+    (cd "${EXAMPLE_DIR}" && docker compose down -v >/dev/null 2>&1) || true
+    rm -rf "${EXAMPLE_DIR}/.smoke-venv"
+    exit "${rc}"
+}
+trap cleanup EXIT
+
+cd "${EXAMPLE_DIR}"
+
+command -v docker >/dev/null || fail "docker is required"
+command -v mysql >/dev/null || fail "mysql client is required (apt-get install mysql-client)"
+command -v python3 >/dev/null || fail "python3 is required"
+docker compose version >/dev/null 2>&1 \
+    || fail "docker compose v2 is required (this script uses 'up --wait' and '--format json')"
+
+log "1/7 docker compose up (waiting for healthchecks — MySQL first-boot is slow, ~20 s)"
+docker compose up -d --wait || fail "docker compose up --wait failed"
+
+log "2/7 verify MySQL and Azurite are healthy"
+for service in mysql azurite; do
+    docker compose ps --format json "${service}" 2>/dev/null \
+        | grep -q '"Health":"healthy"' \
+        || fail "${service} did not become healthy"
+done
+
+log "3/7 apply schema"
+MYSQL_PWD=app mysql -h 127.0.0.1 -P 3306 -u app app \
+    < schema.sql >/dev/null || fail "schema.sql failed"
+
+log "4/7 install Python dependencies"
+python3 -m venv .smoke-venv
+# shellcheck disable=SC1091
+source .smoke-venv/bin/activate
+pip install --quiet --upgrade pip
+pip install --quiet \
+    "azure-functions-db[mysql] @ file://${EXAMPLE_DIR}/../.." \
+    azure-storage-blob \
+    "pymysql>=1.1" \
+    || fail "pip install failed"
+
+log "5/7 seed orders rows"
+# MySQL's TRUNCATE accepts only one table per statement (unlike PG's
+# `TRUNCATE a, b`), so we issue them separately. TRUNCATE also resets
+# AUTO_INCREMENT to 1 automatically — no RESTART IDENTITY clause needed.
+MYSQL_PWD=app mysql -h 127.0.0.1 -P 3306 -u app app <<'SQL' >/dev/null
+TRUNCATE TABLE orders;
+TRUNCATE TABLE processed_orders;
+INSERT INTO orders (customer_name, amount, status)
+VALUES ('Alice', 99.99, 'pending'),
+       ('Bob',   49.50, 'pending');
+UPDATE orders SET status = 'shipped', amount = 109.99
+ WHERE customer_name = 'Alice';
+SQL
+
+log "6/7 drive one poll tick from Python and assert projection"
+MYSQL_URL="${MYSQL_URL}" \
+AZURITE_CONN_STR="${AZURITE_CONN_STR}" \
+CONTAINER_NAME="${CONTAINER_NAME}" \
+python3 - <<'PY'
+import os
+import sys
+from datetime import datetime, timezone
+
+from azure.core.exceptions import ResourceExistsError
+from azure.storage.blob import ContainerClient
+from sqlalchemy import create_engine, text
+
+from azure_functions_db import (
+    BlobCheckpointStore,
+    PollTrigger,
+    RowChange,
+    SqlAlchemySource,
+)
+
+mysql_url = os.environ["MYSQL_URL"]
+azurite = os.environ["AZURITE_CONN_STR"]
+container_name = os.environ["CONTAINER_NAME"]
+
+container = ContainerClient.from_connection_string(
+    conn_str=azurite, container_name=container_name
+)
+try:
+    container.create_container()
+except ResourceExistsError:
+    pass
+
+# `schema=` intentionally omitted — MySQL uses the database name in the
+# URL as the effective schema.
+source = SqlAlchemySource(
+    url=mysql_url,
+    table="orders",
+    cursor_column="updated_at",
+    pk_columns=["id"],
+)
+checkpoint_store = BlobCheckpointStore(
+    container_client=container,
+    source_fingerprint=source.source_descriptor.fingerprint,
+)
+
+dest_engine = create_engine(mysql_url)
+
+
+def handle(events: list[RowChange]) -> None:
+    if not events:
+        return
+    # MySQL DATETIME is TZ-naive; write naive UTC to processed_at so it
+    # matches source_cursor semantics (also naive UTC from the server).
+    processed_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    rows = [
+        {
+            "order_id": e.pk["id"],
+            # event.cursor is (cursor_column, *pk_columns) — keep the timestamp.
+            "source_cursor": e.cursor[0],
+            "customer_name": (e.after or {}).get("customer_name"),
+            "amount": (e.after or {}).get("amount"),
+            "status": (e.after or {}).get("status"),
+            "processed_at": processed_at,
+        }
+        for e in events
+        if e.after is not None
+    ]
+    with dest_engine.begin() as conn:
+        for row in rows:
+            # `INSERT IGNORE` is MySQL's equivalent of PG's
+            # `ON CONFLICT DO NOTHING`: on a PRIMARY KEY / UNIQUE
+            # conflict the row is silently skipped instead of raising.
+            conn.execute(
+                text(
+                    "INSERT IGNORE INTO processed_orders "
+                    "(order_id, source_cursor, customer_name, amount, status, processed_at) "
+                    "VALUES (:order_id, :source_cursor, :customer_name, :amount, :status, "
+                    ":processed_at)"
+                ),
+                row,
+            )
+
+
+trigger = PollTrigger(
+    name="orders",
+    source=source,
+    checkpoint_store=checkpoint_store,
+)
+events_processed = trigger.run(timer=None, handler=handle)
+print(f"[smoke] poll tick processed {events_processed} event(s)")
+
+with dest_engine.begin() as conn:
+    count = conn.execute(text("SELECT COUNT(*) FROM processed_orders")).scalar_one()
+
+if count < 2:
+    print(
+        f"[smoke][FAIL] expected at least 2 processed_orders rows, got {count}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+blobs = list(container.list_blobs())
+if not blobs:
+    print("[smoke][FAIL] no checkpoint blob present in Azurite", file=sys.stderr)
+    sys.exit(1)
+
+print(f"[smoke] processed_orders rows: {count}")
+print(f"[smoke] checkpoint blobs: {[b.name for b in blobs]}")
+PY
+
+log "7/7 assertions passed (cleanup runs via EXIT trap)"
+log "OK — smoke test passed"


### PR DESCRIPTION
## Summary

Adds a runnable MySQL polling-trigger example as a sibling to `examples/postgresql-poll-trigger/` (#100). Same shape — one-minute timer + `@db.trigger` polling an `orders` table with a monotonic cursor + at-least-once idempotent projection into `processed_orders` via `@db.output` upsert — but adapted for MySQL 8.0's dialect and driver quirks. Every deviation from the sibling example is documented inline in the README's dedicated `## MySQL-specific gotchas` section.

Closes #105.

## What changed

**New directory** — `examples/mysql-poll-trigger/` (8 files, ~840 lines)

| File | Purpose |
|---|---|
| `docker-compose.yml` | MySQL 8.0 + Azurite; `--default-time-zone=+00:00`, `TZ=UTC`, healthcheck `retries: 30` (MySQL first-boot init is ~15-30s vs PostgreSQL's ~3s) |
| `schema.sql` | `orders` (source, `DATETIME(6)` cursor with `ON UPDATE CURRENT_TIMESTAMP(6)`, no application-level trigger required) + `processed_orders` (projection, composite PK `(order_id, source_cursor)` for at-least-once idempotence); `utf8mb4_0900_ai_ci` |
| `function_app.py` | Timer `@app.schedule` + `@db.trigger` + `@db.output`; `schema=` omitted; naive UTC datetimes; structure matches the postgres example 1-for-1 so cross-referencing is trivial |
| `host.json` | Identical to postgres example |
| `local.settings.json.example` | `mysql+pymysql://app:app@localhost:3306/app` for both `SOURCE_DB_URL` and `DEST_DB_URL` |
| `requirements.txt` | `azure-functions` + `azure-functions-db[mysql]` (pulls `pymysql>=1.1`) |
| `README.md` | Full end-to-end walkthrough (steps 1–8) + Cursor column choice + Idempotent handler pattern + Checkpoint container configuration + dedicated **MySQL-specific gotchas** section (6 numbered subsections) + Tuning notes |
| `smoke.sh` | Self-contained CI smoke test — bootstraps MySQL + Azurite, applies schema, drives one poll tick from Python via `func-python`-style invocation, asserts projection rows |

**Modified** — `.github/workflows/ci-test.yml`

Extends the existing shellcheck job (previously hardcoded to `examples/postgresql-poll-trigger/smoke.sh`) to also lint the new `examples/mysql-poll-trigger/smoke.sh`. Single-line change on line 81.

## MySQL-specific decisions

The README's `## MySQL-specific gotchas` section covers each of these in prose; abbreviated here:

1. **Timezone handling — DATETIME(6), not TIMESTAMP.** MySQL's `TIMESTAMP` is stored UTC but converted on read using the *session* time zone, making cursor comparisons non-deterministic across workers with different session TZs. `DATETIME` is timezone-naive and stores exactly what is written. Combined with the server flag `--default-time-zone=+00:00` this guarantees `CURRENT_TIMESTAMP(6)` returns UTC.
2. **`ON UPDATE CURRENT_TIMESTAMP(6)` replaces the PG trigger.** MySQL bumps the column automatically on every UPDATE via the column attribute — no stored function, no `BEFORE INSERT OR UPDATE` trigger. One of the small ergonomic wins MySQL has over the PostgreSQL example.
3. **`schema=` argument omitted.** MySQL has no separate schema namespace within a database (the database name in the URL is the effective schema), so the framework's default `schema: str | None = None` is correct. Setting `schema="app"` would fail.
4. **`utf8mb4` / `utf8mb4_0900_ai_ci` charset**, not the legacy `utf8` alias which is 3-byte-only and cannot round-trip 4-byte UTF-8 (most emoji, some CJK).
5. **Driver — PyMySQL via the `[mysql]` extra.** Pure-Python, no C toolchain needed at install time, supports MySQL 8's default `caching_sha2_password` plugin. Native `mysqlclient` alternative documented for users who need 2×–5× throughput.
6. **`TRUNCATE` is single-table.** MySQL rejects `TRUNCATE a, b` (a PostgreSQL-only extension); `smoke.sh` issues two separate statements. `TRUNCATE` also resets `AUTO_INCREMENT` automatically — no `RESTART IDENTITY` clause needed.

The `@db.output` uses `action="upsert"` + `conflict_columns=["order_id", "source_cursor"]`; the framework's writer layer rewrites this to `INSERT ... ON DUPLICATE KEY UPDATE col = VALUES(col)` on MySQL (see [`_UPSERT_DIALECTS`](https://github.com/yeongseon/azure-functions-db-python/blob/main/src/azure_functions_db/binding/writer.py) which includes `"mysql"`, and [`_build_mysql_upsert`](https://github.com/yeongseon/azure-functions-db-python/blob/main/src/azure_functions_db/binding/writer.py) for the compilation path).

## Acceptance checklist (from #105)

- [x] Add `examples/mysql-poll-trigger/` directory
- [x] Include `docker-compose.yml` with MySQL plus Azurite for the checkpoint store
- [x] Include `schema.sql` with a sample table and a monotonic cursor column
- [x] Include `local.settings.json.example` with all required env vars
- [x] Include `function_app.py` demonstrating `SqlAlchemySource` + `BlobCheckpointStore` + a timer-driven `@db.trigger`
- [x] Include a `README.md` with end-to-end run steps
- [x] Note MySQL-specific gotchas (timezone handling, `ON DUPLICATE KEY` upsert, etc.) inline

## Validation

```
hatch run mkdocs build --strict
# Documentation built in 2.20 seconds
# (only the 18 pre-existing not-in-nav INFO entries; unchanged from main)

make lint
# All checks passed!
# Success: no issues found in 64 source files

hatch run ruff check examples/mysql-poll-trigger/
# All checks passed!

hatch run ruff format --check examples/mysql-poll-trigger/
# 1 file already formatted

hatch run pytest --no-cov
# 605 passed, 88 skipped, 19 warnings in ~6.8s
# (skipped = integration tests without TEST_*_URL env vars)

shellcheck examples/mysql-poll-trigger/smoke.sh
# (clean — no findings)
```

The `mysql` integration job in `ci-test.yml` will also exercise the MySQL dialect against the source-tree tests as usual; this PR does not change source-tree code so no behavioural regression is expected.

## Downstream

- Contributes to umbrella #94 (v0.4.0 docs). After this merges the remaining child issues are #104 (MI example), #106 (SQL Server docker-compose example), #107 (blog post).
- Provides the direct pattern-template for #106 SQL Server. That work will follow this same file layout, and the shellcheck workflow line will need one more append (see the `.github/workflows/ci-test.yml` change here).

## References

- Issue: #105
- Sibling PR: #100 (PostgreSQL example — same shape)
- Sibling PR: #174 (vs Official Azure SQL Bindings comparison page — links to `examples/postgresql-poll-trigger/`, will pick up the MySQL example implicitly through the new sibling reference in the mysql README)
- Umbrella: #94
