### PR TITLE
docs: add 'For AI Coding Assistants' section pointing to llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,16 @@ Part of the **Azure Functions Python DX Toolkit**:
 | [azure-functions-knowledge-python](https://github.com/yeongseon/azure-functions-knowledge-python) | Knowledge retrieval (RAG) decorators |
 | [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) | Dogfood examples — runnable recipes that exercise the full toolkit |
 
+## For AI Coding Assistants
+
+This repository includes `llms.txt` and `llms-full.txt` in the root directory.
+These files provide comprehensive package and API information optimized for LLM context windows.
+
+- **`llms.txt`** — Quick reference with core API, installation, and quick-start example
+- **`llms-full.txt`** — Complete reference with full signatures, patterns, design principles, and ecosystem context
+
+Use these files to get better context when working with this package in AI-assisted coding environments.
+
 ## Disclaimer
 
 This project is an independent community project and is not affiliated with,


### PR DESCRIPTION
## Summary
- Adds a `## For AI Coding Assistants` section pointing to the existing `llms.txt` / `llms-full.txt` files (full canonical section).
- Brings db into line with sibling DX Toolkit repos.

Closes #186