### PR TITLE
docs: canonicalize pip install token and clarify async-handler semantics

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -43,22 +43,22 @@ Azure Functions Python v2 には、データベース統合の標準的な仕組
 
 ```bash
 # Core package (pick your database)
-pip install azure-functions-db-python[postgres]
-pip install azure-functions-db-python[mysql]
-pip install azure-functions-db-python[mssql]
+pip install azure-functions-db[postgres]
+pip install azure-functions-db[mysql]
+pip install azure-functions-db[mssql]
 
 # Multiple databases
-pip install azure-functions-db-python[postgres,mysql]
+pip install azure-functions-db[postgres,mysql]
 
 # All drivers
-pip install azure-functions-db-python[all]
+pip install azure-functions-db[all]
 ```
 
 Function App の依存関係には次を含めてください。
 
 ```text
 azure-functions
-azure-functions-db-python[postgres]
+azure-functions-db[postgres]
 ```
 
 ## Quick Start
@@ -277,9 +277,9 @@ def orders_poll(timer: func.TimerRequest, events: list[RowChange], out: DbOut) -
 
 | Database | Extra | Driver |
 |----------|-------|--------|
-| PostgreSQL | `azure-functions-db-python[postgres]` | [psycopg](https://www.psycopg.org/) |
-| MySQL | `azure-functions-db-python[mysql]` | [PyMySQL](https://pymysql.readthedocs.io/) |
-| SQL Server | `azure-functions-db-python[mssql]` | [pyodbc](https://github.com/mkleehammer/pyodbc) |
+| PostgreSQL | `azure-functions-db[postgres]` | [psycopg](https://www.psycopg.org/) |
+| MySQL | `azure-functions-db[mysql]` | [PyMySQL](https://pymysql.readthedocs.io/) |
+| SQL Server | `azure-functions-db[mssql]` | [pyodbc](https://github.com/mkleehammer/pyodbc) |
 
 ## Scope
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -43,22 +43,22 @@ Azure Functions Python v2에는 데이터베이스 통합에 대한 기본 스�
 
 ```bash
 # Core package (pick your database)
-pip install azure-functions-db-python[postgres]
-pip install azure-functions-db-python[mysql]
-pip install azure-functions-db-python[mssql]
+pip install azure-functions-db[postgres]
+pip install azure-functions-db[mysql]
+pip install azure-functions-db[mssql]
 
 # Multiple databases
-pip install azure-functions-db-python[postgres,mysql]
+pip install azure-functions-db[postgres,mysql]
 
 # All drivers
-pip install azure-functions-db-python[all]
+pip install azure-functions-db[all]
 ```
 
 Function App 의존성에는 다음이 포함되어야 합니다.
 
 ```text
 azure-functions
-azure-functions-db-python[postgres]
+azure-functions-db[postgres]
 ```
 
 ## 빠른 시작
@@ -277,9 +277,9 @@ def orders_poll(timer: func.TimerRequest, events: list[RowChange], out: DbOut) -
 
 | Database | Extra | Driver |
 |----------|-------|--------|
-| PostgreSQL | `azure-functions-db-python[postgres]` | [psycopg](https://www.psycopg.org/) |
-| MySQL | `azure-functions-db-python[mysql]` | [PyMySQL](https://pymysql.readthedocs.io/) |
-| SQL Server | `azure-functions-db-python[mssql]` | [pyodbc](https://github.com/mkleehammer/pyodbc) |
+| PostgreSQL | `azure-functions-db[postgres]` | [psycopg](https://www.psycopg.org/) |
+| MySQL | `azure-functions-db[mysql]` | [PyMySQL](https://pymysql.readthedocs.io/) |
+| SQL Server | `azure-functions-db[mssql]` | [pyodbc](https://github.com/mkleehammer/pyodbc) |
 
 ## 범위
 

--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ This package does **not** implement a native Azure Functions trigger extension. 
 
 This package does **not** use SQLAlchemy `AsyncEngine` internally. If you need fully native asyncio drivers (e.g. `asyncpg`, `aiomysql`), drive them yourself outside the binding — `azure-functions-db` deliberately exposes a single sync engine path so behavior across dialects stays identical.
 
+> **Exception — `@db.trigger` does not support async handlers.** Because `PollTrigger.run()` is synchronous, the `trigger` decorator rejects an async handler at decoration time by raising `ConfigurationError`; `PollTrigger.run()` additionally raises `TypeError` as a defensive runtime guard if it is ever handed an async callable. Use a synchronous handler for `@db.trigger`.
+
 ### Async writer transactions
 
 The async writer proxy injected by `@db.inject_writer` into `async def` handlers exposes `insert`, `insert_many`, `upsert`, `upsert_many`, and `close` — but **does not** expose a `transaction()` context manager. SQLAlchemy `Connection` / `Transaction` objects are not safe to share across threads, and `asyncio.to_thread` does not pin work to a single OS thread, so a per-call async transaction would silently break atomicity.
@@ -536,6 +538,8 @@ See [Semantics — Duplicate Windows](docs/03-semantics.md#13-duplicate-and-repr
 - [Semantics](docs/03-semantics.md)
 - [Python API Spec](docs/04-python-api-spec.md)
 - [Adapter SDK](docs/05-adapter-sdk.md)
+
+> **Canonical sources.** The numbered specs and ADRs (`docs/00-*` … `docs/28-*`) are canonical for design and the API contract — [`docs/04-python-api-spec.md`](docs/04-python-api-spec.md) is authoritative. The standard site pages and the auto-generated API reference are derivations. When behavior changes, update `04-python-api-spec.md` first, then the user-facing pages.
 
 ## Ecosystem
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,22 +43,22 @@ Azure Functions Python v2 缺少内置的数据库集成方案：
 
 ```bash
 # Core package (pick your database)
-pip install azure-functions-db-python[postgres]
-pip install azure-functions-db-python[mysql]
-pip install azure-functions-db-python[mssql]
+pip install azure-functions-db[postgres]
+pip install azure-functions-db[mysql]
+pip install azure-functions-db[mssql]
 
 # Multiple databases
-pip install azure-functions-db-python[postgres,mysql]
+pip install azure-functions-db[postgres,mysql]
 
 # All drivers
-pip install azure-functions-db-python[all]
+pip install azure-functions-db[all]
 ```
 
 你的 Function App 依赖应包含：
 
 ```text
 azure-functions
-azure-functions-db-python[postgres]
+azure-functions-db[postgres]
 ```
 
 ## Quick Start
@@ -277,9 +277,9 @@ def orders_poll(timer: func.TimerRequest, events: list[RowChange], out: DbOut) -
 
 | Database | Extra | Driver |
 |----------|-------|--------|
-| PostgreSQL | `azure-functions-db-python[postgres]` | [psycopg](https://www.psycopg.org/) |
-| MySQL | `azure-functions-db-python[mysql]` | [PyMySQL](https://pymysql.readthedocs.io/) |
-| SQL Server | `azure-functions-db-python[mssql]` | [pyodbc](https://github.com/mkleehammer/pyodbc) |
+| PostgreSQL | `azure-functions-db[postgres]` | [psycopg](https://www.psycopg.org/) |
+| MySQL | `azure-functions-db[mysql]` | [PyMySQL](https://pymysql.readthedocs.io/) |
+| SQL Server | `azure-functions-db[mssql]` | [pyodbc](https://github.com/mkleehammer/pyodbc) |
 
 ## Scope
 

--- a/docs/00-project-overview.md
+++ b/docs/00-project-overview.md
@@ -55,7 +55,7 @@ Change detection (trigger), reading (input binding), and writing (output binding
 
 Make Azure Functions developers think:
 
-> "If I need to work with a database, I just install azure-functions-db-python."
+> "If I need to work with a database, I just install azure-functions-db."
 
 ## MVP Scope
 

--- a/docs/04-python-api-spec.md
+++ b/docs/04-python-api-spec.md
@@ -162,8 +162,10 @@ def handler(events): ...
 def handler(events, context): ...
 ```
 
-> **Note**: Async handlers are not supported and will raise `TypeError`.
-> Async support may be added in a future version.
+> **Note**: Async handlers are not supported. The `trigger` decorator rejects them
+> at decoration time by raising `ConfigurationError` (`decorator.py`); as a defensive
+> runtime guard, `PollTrigger.run()` also raises `TypeError` if it is ever handed an
+> async callable (`trigger/poll.py`). Async support may be added in a future version.
 
 Rules:
 - `events` may be empty. Default behavior is **empty batch skip**.

--- a/docs/04-python-api-spec.md
+++ b/docs/04-python-api-spec.md
@@ -163,9 +163,9 @@ def handler(events, context): ...
 ```
 
 > **Note**: Async handlers are not supported. The `trigger` decorator rejects them
-> at decoration time by raising `ConfigurationError` (`decorator.py`); as a defensive
+> at decoration time by raising `ConfigurationError` (`src/azure_functions_db/decorator.py`); as a defensive
 > runtime guard, `PollTrigger.run()` also raises `TypeError` if it is ever handed an
-> async callable (`trigger/poll.py`). Async support may be added in a future version.
+> async callable (`src/azure_functions_db/trigger/poll.py`). Async support may be added in a future version.
 
 Rules:
 - `events` may be empty. Default behavior is **empty batch skip**.

--- a/docs/12-security.md
+++ b/docs/12-security.md
@@ -58,6 +58,6 @@ When handling multiple tenant DBs simultaneously:
 - Separate optional drivers as extras
 
 Examples:
-- `azure-functions-db-python[postgres]`
-- `azure-functions-db-python[mysql]`
-- `azure-functions-db-python[mssql]`
+- `azure-functions-db[postgres]`
+- `azure-functions-db[mysql]`
+- `azure-functions-db[mssql]`

--- a/docs/23-ADR-005-unified-package-design.md
+++ b/docs/23-ADR-005-unified-package-design.md
@@ -49,7 +49,7 @@ trigger (change detection) and binding (read/write) in a single package.
 ## Rationale
 
 1. **Technical synergy**: natural sharing of engine/config/pool
-2. **User convenience**: a single `pip install azure-functions-db-python` covers all DB operations
+2. **User convenience**: a single `pip install azure-functions-db` covers all DB operations
 3. **Scope management**: internal core/trigger/binding separation isolates complexity
 4. **Incremental delivery**: trigger implemented first; binding added in Phase 8+
 5. **Design review**: adopted recommendation of "one package, but not one programming model"

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,7 @@
 # API Reference
 
+> Auto-generated from source via mkdocstrings. For the hand-written API contract and design rationale (handler rules, source modes, semantics), see the canonical [Python API Spec](04-python-api-spec.md).
+
 ::: azure_functions_db
     options:
       show_root_heading: true

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,8 +5,8 @@
 ### What databases are supported?
 
 **Built-in extras** (driver included): PostgreSQL, MySQL, and SQL Server. Install the
-corresponding extra: `azure-functions-db-python[postgres]`, `azure-functions-db-python[mysql]`,
-or `azure-functions-db-python[mssql]`.
+corresponding extra: `azure-functions-db[postgres]`, `azure-functions-db[mysql]`,
+or `azure-functions-db[mssql]`.
 
 **Any SQLAlchemy dialect**: The bindings and `SqlAlchemySource` are designed to work with
 any database that has a SQLAlchemy driver — Oracle, CockroachDB, SQLite, DuckDB, etc.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,14 +22,14 @@ Before starting, make sure you have:
 3. A running database (PostgreSQL, MySQL, or SQL Server).
 4. Dependencies installed:
     - `azure-functions`
-    - `azure-functions-db-python[postgres]` (or your database extra)
+    - `azure-functions-db[postgres]` (or your database extra)
 
 See [Installation](installation.md) for version details.
 
 ## Step 1: Install the package
 
 ```bash
-pip install azure-functions-db-python[postgres]
+pip install azure-functions-db[postgres]
 ```
 
 ## Step 2: Add an input binding

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Unified DB integration (trigger + input/output binding) for Azure Functions Pyth
 ## Quick Start
 
 ```bash
-pip install azure-functions-db-python[postgres]
+pip install azure-functions-db[postgres]
 ```
 
 ```python
@@ -30,3 +30,12 @@ from azure_functions_db import SqlAlchemySource, BlobCheckpointStore, EngineProv
 - [API Reference](api.md) — auto-generated API docs
 - [Troubleshooting](troubleshooting.md) — common issues and solutions
 - [FAQ](faq.md) — frequently asked questions
+
+## Docs ownership & canonical sources
+
+This project maintains two complementary documentation sets:
+
+- **Numbered specs & ADRs** (`00-*` … `28-*`, including the ADRs) are the **canonical source for design and API contract**. `04-python-api-spec.md` is the authoritative API reference; the auto-generated [API Reference](api.md) is derived from source and cross-links back to it.
+- **Standard user-facing pages** (this index, [Installation](installation.md), [Getting Started](getting-started.md), [Troubleshooting](troubleshooting.md), [FAQ](faq.md)) are **derivations** tuned for task-oriented reading.
+
+**When changing behavior, update `04-python-api-spec.md` first, then propagate to the user-facing pages** so the two systems do not drift.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,22 +32,22 @@ Install with the driver extra for your database:
 
 ```bash
 # Pick your database
-pip install azure-functions-db-python[postgres]
-pip install azure-functions-db-python[mysql]
-pip install azure-functions-db-python[mssql]
+pip install azure-functions-db[postgres]
+pip install azure-functions-db[mysql]
+pip install azure-functions-db[mssql]
 
 # Multiple databases
-pip install azure-functions-db-python[postgres,mysql]
+pip install azure-functions-db[postgres,mysql]
 
 # All drivers
-pip install azure-functions-db-python[all]
+pip install azure-functions-db[all]
 ```
 
 Your Function App dependencies should include:
 
 ```text
 azure-functions
-azure-functions-db-python[postgres]
+azure-functions-db[postgres]
 ```
 
 ## Verify Installation
@@ -86,7 +86,7 @@ All project maintenance commands should go through the Makefile.
 Upgrade to the latest published version:
 
 ```bash
-pip install --upgrade azure-functions-db-python[postgres]
+pip install --upgrade azure-functions-db[postgres]
 ```
 
 Recommended upgrade workflow:
@@ -103,12 +103,12 @@ For deterministic deployments, pin an explicit version in your dependency file.
 ### ImportError: No module named `azure_functions_db`
 
 - Confirm installation ran in the correct environment.
-- Run `python -m pip install azure-functions-db-python[postgres]`.
+- Run `python -m pip install azure-functions-db[postgres]`.
 - Verify with `python -c "import azure_functions_db"`.
 
 ### Driver not found (psycopg, pymysql, pyodbc)
 
-- Confirm you installed the correct extra: `pip install azure-functions-db-python[postgres]`.
+- Confirm you installed the correct extra: `pip install azure-functions-db[postgres]`.
 - Run `pip show psycopg` (or `pymysql`, `pyodbc`) to verify the driver is present.
 - SQL Server requires ODBC Driver 17+ installed at the OS level.
 
@@ -120,5 +120,5 @@ For deterministic deployments, pin an explicit version in your dependency file.
 ### Runtime dependency drift in Azure
 
 - Rebuild deployment artifacts from a clean environment.
-- Confirm `requirements.txt` includes both `azure-functions` and `azure-functions-db-python[postgres]`.
+- Confirm `requirements.txt` includes both `azure-functions` and `azure-functions-db[postgres]`.
 - Verify the deployed Python runtime version is compatible with your lockfile.

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -133,7 +133,7 @@ make publish-test       # Publish to TestPyPI
 To install from TestPyPI:
 
 ```bash
-pip install --index-url https://test.pypi.org/simple/ azure-functions-db-python
+pip install --index-url https://test.pypi.org/simple/ azure-functions-db
 ```
 
 ---

--- a/docs/security.md
+++ b/docs/security.md
@@ -81,9 +81,9 @@ When handling multiple tenant databases:
 - Pin dependencies in `requirements.txt` or a lock file.
 - Run vulnerability scanning in CI (e.g. `pip-audit`, `safety`).
 - Database drivers are installed as optional extras — only install what you need:
-    - `azure-functions-db-python[postgres]`
-    - `azure-functions-db-python[mysql]`
-    - `azure-functions-db-python[mssql]`
+    - `azure-functions-db[postgres]`
+    - `azure-functions-db[mysql]`
+    - `azure-functions-db[mssql]`
 
 ## Reporting Security Issues
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,16 +7,16 @@ Common issues and solutions for `azure-functions-db-python`.
 ### ImportError: No module named `azure_functions_db`
 
 - Confirm installation ran in the correct virtual environment.
-- Run `python -m pip install azure-functions-db-python[postgres]`.
+- Run `python -m pip install azure-functions-db[postgres]`.
 - Verify with `python -c "import azure_functions_db"`.
 - Check that the active environment matches the one your Function App uses.
 
 ### Driver not found (psycopg, pymysql, pyodbc)
 
 - Confirm you installed the correct database extra:
-    - PostgreSQL: `pip install azure-functions-db-python[postgres]`
-    - MySQL: `pip install azure-functions-db-python[mysql]`
-    - SQL Server: `pip install azure-functions-db-python[mssql]`
+    - PostgreSQL: `pip install azure-functions-db[postgres]`
+    - MySQL: `pip install azure-functions-db[mysql]`
+    - SQL Server: `pip install azure-functions-db[mssql]`
 - Verify the driver is installed: `pip show psycopg` (or `pymysql`, `pyodbc`).
 - SQL Server requires ODBC Driver 17+ installed at the OS level.
 
@@ -101,7 +101,7 @@ Common issues and solutions for `azure-functions-db-python`.
 
 ### Works locally but fails in Azure
 
-- Confirm `requirements.txt` includes the driver extra: `azure-functions-db-python[postgres]`.
+- Confirm `requirements.txt` includes the driver extra: `azure-functions-db[postgres]`.
 - Confirm environment variables are set in Azure Portal > Function App > Configuration.
 - Verify the deployed Python runtime version matches your local version.
 - Rebuild deployment artifacts from a clean environment to avoid stale dependencies.

--- a/examples/byod_oracle/function_app.py
+++ b/examples/byod_oracle/function_app.py
@@ -8,7 +8,7 @@ applies to CockroachDB, DuckDB, or any other database that has a
 SQLAlchemy dialect — just swap the driver and connection URL.
 
 Prerequisites:
-    pip install azure-functions-db-python oracledb
+    pip install azure-functions-db oracledb
 
 Environment variables:
     ORACLE_DB_URL: Oracle connection string

--- a/examples/poll_orders/function_app.py
+++ b/examples/poll_orders/function_app.py
@@ -1,7 +1,7 @@
 """Example: Poll orders table for changes using DbBindings decorators.
 
 Prerequisites:
-    pip install azure-functions-db-python[postgres]
+    pip install azure-functions-db[postgres]
 
 Environment variables:
     ORDERS_DB_URL: PostgreSQL connection string

--- a/examples/trigger_with_binding/function_app.py
+++ b/examples/trigger_with_binding/function_app.py
@@ -8,8 +8,8 @@ Shows two patterns:
     2. ``inject_writer`` — client injection (imperative, for complex operations)
 
 Requirements:
-    pip install azure-functions-db-python[postgres]
-    # or: pip install azure-functions-db-python[all]
+    pip install azure-functions-db[postgres]
+    # or: pip install azure-functions-db[all]
 
 Environment variables:
     SOURCE_DB_URL: Source database connection URL

--- a/examples/usage_byod.py
+++ b/examples/usage_byod.py
@@ -10,8 +10,8 @@ works with any SQLAlchemy dialect:
     Firebird:     firebird+fdb://user:pass@host/db
 
 Prerequisites:
-    pip install azure-functions-db-python <your-driver>
-    # e.g. pip install azure-functions-db-python oracledb
+    pip install azure-functions-db <your-driver>
+    # e.g. pip install azure-functions-db oracledb
 
 Usage:
     ORACLE_DB_URL="oracle+oracledb://user:pass@host:1521/?service_name=XEPDB1"


### PR DESCRIPTION
## Summary

Aligns documentation with the actual PyPI distribution name and the implemented async-handler rejection behavior.

- **Pip-token canonicalization** — all `pip install` commands and driver-extra tokens changed from `azure-functions-db-python[...]` to the real PyPI dist name `azure-functions-db[...]` across `docs/`, `examples/`, and the ja/ko/zh-CN READMEs. GitHub-repo URLs, badges, and PyPI project links are intentionally left as `-python` (that is the GitHub repo name, verified via `pyproject.toml` `name = "azure-functions-db"` and `tests/test_public_api.py`).
- **Async-handler semantics** — corrected the wording that previously said async handlers "raise `TypeError`". The `trigger` decorator rejects async handlers at decoration time with `ConfigurationError` (`decorator.py`), and `PollTrigger.run()` raises `TypeError` only as a defensive runtime guard (`trigger/poll.py`). Updated `docs/04-python-api-spec.md` and `README.md`. (`docs/02-architecture.md` was already accurate.)
- **Docs ownership note** — added a "Docs ownership & canonical sources" note to `docs/index.md` and `README.md`, and cross-linked the auto-generated `docs/api.md` to the canonical `docs/04-python-api-spec.md`.

## Scope

Docs-only. Deferred to follow-up **#192**: i18n async-wording translation (ja/ko/zh-CN) and the docs-drift CI guard + async-rejection unit test.

## Verification

- `hatch run mkdocs build --strict` passes (only pre-existing not-in-nav INFO notices).

Part of #189
