### PR TITLE
docs: enable mermaid rendering and add canonical poll-trigger diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,17 +329,18 @@ sequenceDiagram
 
     Timer->>PT: PollTrigger.run(timer, handler)
     PT->>PR: tick()
-    PR->>CS: acquire_lease() (ETag CAS)
-    CS-->>PR: lease granted
+    PR->>CS: acquire_lease()
+    CS-->>PR: lease_id
     PR->>CS: load_checkpoint()
     CS-->>PR: last cursor
     PR->>SRC: fetch(cursor, batch_size)
     SRC->>DB: SELECT ... WHERE cursor_column > :cursor
     DB-->>SRC: changed rows
-    SRC-->>PR: RowChange events
+    SRC-->>PR: raw records (dicts)
+    PR->>PR: normalize records → RowChange events
     PR->>H: handler(events)
     H-->>PR: success
-    PR->>CS: commit_checkpoint(new cursor, ETag)
+    PR->>CS: commit_checkpoint(checkpoint, lease_id)
     Note over PR,CS: at-least-once — commit after handler success;<br/>a crash before commit re-delivers the batch
 ```
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,38 @@ Notes:
 >
 > Delivery is **at-least-once**. Duplicates may occur during process crashes, lease transitions, or checkpoint commit failures. **Handlers must be idempotent.** See [Polling Runtime & Failure Scenarios](docs/24-polling-runtime-semantics.md) for the full operational reference (tick lifecycle, duplicate windows, lease tuning, recovery procedures), [Production Checklist](docs/26-polling-production-checklist.md) before going to production, and [Semantics — Duplicate Windows](docs/03-semantics.md#13-duplicate-and-reprocessing-windows) for the formal contract.
 
+#### Poll-trigger lifecycle
+
+One `PollRunner.tick()` per timer fire, using the concrete default components (`BlobCheckpointStore` + `SqlAlchemySource`):
+
+```mermaid
+sequenceDiagram
+    participant Timer as Azure Timer Trigger
+    participant PT as PollTrigger
+    participant PR as PollRunner
+    participant CS as BlobCheckpointStore
+    participant SRC as SqlAlchemySource
+    participant DB as Database
+    participant H as Handler
+
+    Timer->>PT: PollTrigger.run(timer, handler)
+    PT->>PR: tick()
+    PR->>CS: acquire_lease() (ETag CAS)
+    CS-->>PR: lease granted
+    PR->>CS: load_checkpoint()
+    CS-->>PR: last cursor
+    PR->>SRC: fetch(cursor, batch_size)
+    SRC->>DB: SELECT ... WHERE cursor_column > :cursor
+    DB-->>SRC: changed rows
+    SRC-->>PR: RowChange events
+    PR->>H: handler(events)
+    H-->>PR: success
+    PR->>CS: commit_checkpoint(new cursor, ETag)
+    Note over PR,CS: at-least-once — commit after handler success;<br/>a crash before commit re-delivers the batch
+```
+
+> The full architecture reference (with `StateStore` / `SourceAdapter` protocol names) lives in [Architecture — Trigger Flow](docs/02-architecture.md#trigger-flow-poll-based-change-detection).
+
 ```python
 import azure.functions as func
 from azure.storage.blob import ContainerClient

--- a/docs/16-ADR-001-pseudo-trigger-over-native.md
+++ b/docs/16-ADR-001-pseudo-trigger-over-native.md
@@ -36,3 +36,22 @@ Disadvantages:
 
 ## Follow-up
 Even if native capabilities are added for specific databases in the future, the public API will remain stable.
+
+## Diagram
+
+This decision means change detection runs as a timer-driven poll loop inside the
+worker, rather than a host-managed native push trigger:
+
+```mermaid
+flowchart LR
+    Timer[Azure Timer Trigger] --> PT["@db.trigger / PollTrigger.run()"]
+    PT --> PR["PollRunner.tick()"]
+    PR -->|acquire_lease / load_checkpoint / commit| CS[BlobCheckpointStore]
+    PR -->|fetch cursor greater than checkpoint| SRC[SqlAlchemySource]
+    SRC --> DB[(Database)]
+    PR --> H[User Handler]
+```
+
+For the full step-by-step lifecycle (lease, checkpoint, fetch, commit ordering and
+the at-least-once window) see the canonical
+[Poll-trigger lifecycle diagram](02-architecture.md#trigger-flow-poll-based-change-detection).

--- a/docs/17-ADR-002-sqlalchemy-centric-adapter.md
+++ b/docs/17-ADR-002-sqlalchemy-centric-adapter.md
@@ -31,3 +31,20 @@ SQLAlchemy Core offers the best balance among the alternatives.
 - RDBMS reach achieved quickly
 - Driver selection possible via package extras
 - Non-SQL stores such as MongoDB maintain separate adapters
+
+## Diagram
+
+A single SQLAlchemy Core layer sits between the bindings/source and every supported
+dialect, so the trigger and binding machinery never depends on a specific driver:
+
+```mermaid
+flowchart TD
+    Bindings["DbBindings / DbReader / DbWriter / SqlAlchemySource"] --> Core[SQLAlchemy Core]
+    Core --> PG[(PostgreSQL)]
+    Core --> MY[(MySQL)]
+    Core --> MS[(SQL Server)]
+    Core --> OT[(Oracle / SQLite / any dialect)]
+```
+
+See the [Poll-trigger lifecycle diagram](02-architecture.md#trigger-flow-poll-based-change-detection)
+for how `SqlAlchemySource.fetch()` fits into the polling loop.

--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -1,0 +1,15 @@
+(function () {
+  if (typeof mermaid === "undefined") return;
+
+  mermaid.initialize({ startOnLoad: false });
+
+  var renderMermaid = function () {
+    mermaid.run({ querySelector: ".mermaid" });
+  };
+
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(renderMermaid);
+  } else {
+    document.addEventListener("DOMContentLoaded", renderMermaid);
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,11 @@ markdown_extensions:
       permalink: true
       toc_depth: 3
   - tables
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_div_format
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.tabbed:
@@ -80,3 +84,7 @@ extra:
       link: https://github.com/yeongseon/azure-functions-db-python
   copyright: |
     © 2026 Yeongseon Choe – MIT Licensed
+
+extra_javascript:
+  - https://unpkg.com/mermaid@11/dist/mermaid.min.js
+  - javascripts/mermaid-init.js


### PR DESCRIPTION
## Summary

Fixes the confirmed docs-site Mermaid rendering defect and adds a canonical poll-trigger lifecycle diagram.

- **Mermaid rendering (P1 defect)** — `mkdocs.yml` had a bare `pymdownx.superfences` with no mermaid custom fence and no `mermaid.min.js`, so the three `docs/02-architecture.md` sequence diagrams rendered as plain code blocks. Added the mermaid custom fence + `mermaid.min.js` + `javascripts/mermaid-init.js`, mirroring the working `openapi`/`logging` config.
- **Canonical lifecycle diagram** — added a "Poll-trigger lifecycle" `sequenceDiagram` to `README.md` using the concrete default components (`PollTrigger.run()` → `PollRunner.tick()` → `BlobCheckpointStore` acquire_lease/load_checkpoint → `SqlAlchemySource.fetch()` → Handler → commit ETag/CAS), cross-linked to the architecture reference (which already carries the protocol-level version).
- **ADR diagrams** — `docs/16-ADR-001` and `docs/17-ADR-002` gained illustrative Mermaid diagrams and cross-links to the canonical lifecycle diagram.

## Verification

- `hatch run mkdocs build --strict` passes (rc=0).

Closes #190
