### PR TITLE
chore(test): align e2e marker filter and correct Codecov version comment

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.10' && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ module = "examples.*"
 follow_imports = "skip"
 
 [tool.pytest.ini_options]
-addopts = "--cov=src/azure_functions_db --cov-report=xml --cov-report=term-missing -ra -q"
+addopts = '--cov=src/azure_functions_db --cov-report=xml --cov-report=term-missing -ra -q -m "not host_e2e and not azure_e2e"'
 testpaths = ["tests"]
 pythonpath = ["src", "."]
 markers = [


### PR DESCRIPTION
## Summary

Aligns the test suite defaults and CI config with the sibling toolkit repos.

- **e2e marker parity** — the default `addopts` had no e2e exclusion, so the end-to-end smoke tests were collected on a plain `hatch run test`. db tags its e2e tests with `host_e2e` / `azure_e2e` (there is no bare `e2e` marker as in some siblings), so the faithful parity filter is `-m "not host_e2e and not azure_e2e"`. This excludes the 10 host/azure smoke tests (`tests/e2e/host` × 7, `tests/e2e/azure` × 3) that require `func start` / Azure resources, matching the siblings' `-m 'not e2e'` intent for this repo's marker taxonomy.
- **Codecov version comment** — `.github/workflows/ci-test.yml` pinned `codecov/codecov-action@fb8b358…` with a `# v7.0.0` comment, but that SHA is the **v5** release (6 siblings comment it `# v5`). Corrected the comment (pin unchanged).

## Verification (item 3, static/coverage)

- Full suite passes; total coverage **95.16%** (≥ 95 `fail_under`).
- CAS/lease correctness surface `state/blob.py` at **97%**; poll retry/idempotency surface `trigger/runner.py` at **93%** (+ `trigger/poll.py`), exercised by `tests/test_trigger_retry.py` and the checkpoint-store tests — failure paths asserted with real semantics.
- Confirmed the e2e-family tests are excluded from default collection after the change.

Closes #191
