### PR TITLE
refactor(state): de-duplicate release_lease via _verify_lease

### DIFF
--- a/src/azure_functions_db/state/blob.py
+++ b/src/azure_functions_db/state/blob.py
@@ -179,10 +179,13 @@ class BlobCheckpointStore:
         state: dict[str, Any],
         owner_id: str,
         fencing_token: int,
+        *,
+        check_expiry: bool = True,
     ) -> None:
         """Verify that the caller is the current lease holder.
 
-        Raises ``LostLeaseError`` on any mismatch or if the lease has expired.
+        Raises ``LostLeaseError`` on any mismatch, or (when ``check_expiry`` is
+        ``True``) if the lease has expired.
         """
         lease = state.get("lease")
         if lease is None:
@@ -200,7 +203,7 @@ class BlobCheckpointStore:
             )
 
         expires_at_str = lease.get("expires_at")
-        if expires_at_str is not None:
+        if check_expiry and expires_at_str is not None:
             expires_at = datetime.fromisoformat(expires_at_str)
             if _now_utc() > expires_at:
                 raise LostLeaseError("Lease has expired")
@@ -359,18 +362,7 @@ class BlobCheckpointStore:
 
         state, etag = result
 
-        lease = state.get("lease")
-        if lease is None:
-            raise LostLeaseError("No lease present in state")
-        if lease.get("owner_id") != owner_id:
-            raise LostLeaseError(
-                f"Lease owner mismatch: expected '{owner_id}', found '{lease.get('owner_id')}'"
-            )
-        if lease.get("fencing_token") != fencing_token:
-            raise LostLeaseError(
-                f"Fencing token mismatch: expected {fencing_token}, "
-                f"found {lease.get('fencing_token')}"
-            )
+        self._verify_lease(state, owner_id, fencing_token, check_expiry=False)
 
         state["lease"]["expires_at"] = _iso(_now_utc())
 


### PR DESCRIPTION
## Summary

Ships the safe, mechanical subset of the design-review refactor backlog: de-duplicating the lease-release verification in `state/blob.py`.

- `_verify_lease` gains a keyword-only `check_expiry: bool = True` parameter, guarding only the expiry branch.
- `release_lease` now calls `self._verify_lease(state, owner_id, fencing_token, check_expiry=False)` instead of re-implementing the owner_id / fencing_token / lease-present checks inline. The intentional "skip expiry so a holder can release a nominally-expired-but-unstolen lease" semantics are preserved.

Net: -14/+6 lines, identical behavior (same `LostLeaseError` messages, same CAS 412 handling).

## Scope & deferrals

The remaining #188 items each change a critical code path or a public/contract surface, so they are deferred to follow-up **#196** for focused, test-guarded PRs rather than bundling here:

- Decompose `PollRunner.tick()` (~490-line god method).
- Collapse the 5× sync/async decorator duplication (core dispatch path).
- Unify the triplicated init/reflect/validate lifecycle (`ReflectMixin`).
- Collapse the `_Async*Proxy` classes — a naive generic `__getattr__` proxy would erase the explicit typed signatures **and** expose `DbWriter.transaction()`, which the async writer proxy intentionally withholds.
- Type the cross-package toolkit-metadata contract (cross-repo).

## Verification

- Full suite passes; total coverage **95.34%** (≥ 95).
- `make typecheck` (mypy) and `make lint` (ruff) both clean.

Part of #188
