### PR TITLE
docs: add discoverability metadata (pepy badge + llms.txt)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,7 @@
 # Azure Functions DB
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-db-python.svg)](https://pypi.org/project/azure-functions-db-python/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-db/month)](https://pepy.tech/project/azure-functions-db)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-db-python/)
 [![CI](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml)

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,7 @@
 # Azure Functions DB
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-db-python.svg)](https://pypi.org/project/azure-functions-db-python/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-db/month)](https://pepy.tech/project/azure-functions-db)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-db-python/)
 [![CI](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-db.svg)](https://pypi.org/project/azure-functions-db/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-db/month)](https://pepy.tech/project/azure-functions-db)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-db/)
 [![CI](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,7 @@
 # Azure Functions DB
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-db-python.svg)](https://pypi.org/project/azure-functions-db-python/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-db/month)](https://pepy.tech/project/azure-functions-db)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-db-python/)
 [![CI](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,27 @@
+# Azure Functions DB
+
+> Database trigger and input/output bindings for Azure Functions Python v2, powered by SQLAlchemy.
+
+Part of the **Azure Functions Python DX Toolkit**. SQLAlchemy-backed database bindings and a pseudo-trigger for Azure Functions Python v2 — read, write, and react to database changes with a decorator-based API. Install from PyPI with `pip install azure-functions-db`.
+
+## Getting Started
+- [Installation](https://yeongseon.github.io/azure-functions-db-python/installation/): Install the package.
+- [Quickstart](https://yeongseon.github.io/azure-functions-db-python/getting-started/): Minimal end-to-end example.
+
+## User Guide
+- [Architecture](https://yeongseon.github.io/azure-functions-db-python/02-architecture/): How the bindings and runtime fit together.
+- [Binding Semantics](https://yeongseon.github.io/azure-functions-db-python/22-binding-semantics/): Input/output binding behavior.
+- [Polling Runtime & Failure Scenarios](https://yeongseon.github.io/azure-functions-db-python/24-polling-runtime-semantics/): Trigger runtime semantics.
+- [EngineProvider & Pooling](https://yeongseon.github.io/azure-functions-db-python/25-engine-provider-pooling/): Connection pooling.
+- [Python API Spec](https://yeongseon.github.io/azure-functions-db-python/04-python-api-spec/): Public API.
+
+## Examples
+- [Input Binding](https://yeongseon.github.io/azure-functions-db-python/examples/input_binding/): Read rows.
+- [Output Binding](https://yeongseon.github.io/azure-functions-db-python/examples/output_binding/): Write rows.
+- [Trigger](https://yeongseon.github.io/azure-functions-db-python/examples/trigger/): React to changes.
+- [Client Injection](https://yeongseon.github.io/azure-functions-db-python/examples/client_injection/): Imperative access.
+
+## Reference
+- [API Reference](https://yeongseon.github.io/azure-functions-db-python/api/): Public API surface.
+- [FAQ](https://yeongseon.github.io/azure-functions-db-python/faq/): Frequently asked questions.
+- [Troubleshooting](https://yeongseon.github.io/azure-functions-db-python/troubleshooting/): Common issues and fixes.


### PR DESCRIPTION
## Summary

Discoverability improvements (no code changes):

- **pepy.tech monthly download badge** added to `README.md` and locale READMEs (after the PyPI badge).
- **`docs/llms.txt`** added — an llmstxt.org-style summary served at the gh-pages site root (`/llms.txt`) with curated links to key docs.

## Verification
- `mkdocs build` succeeds; `llms.txt` present at site root.


Closes #199
