### PR TITLE
refactor(binding): extract shared validate_pk_columns helper

### DIFF
--- a/src/azure_functions_db/binding/reader.py
+++ b/src/azure_functions_db/binding/reader.py
@@ -13,6 +13,7 @@ from ..core.config import DbConfig, resolve_env_vars
 from ..core.engine import EngineProvider
 from ..core.errors import ConfigurationError, DbConnectionError, QueryError
 from ..core.metadata import get_metadata_cache
+from ..core.validation import validate_pk_columns
 
 logger = logging.getLogger(__name__)
 
@@ -442,31 +443,4 @@ class DbReader:
     def _validate_pk_columns(self, pk: dict[str, object]) -> None:
         """Validate that *pk* keys exactly match the table's primary key columns."""
         assert self._table is not None  # noqa: S101  # nosec B101
-
-        if not pk:
-            msg = "pk must not be empty"
-            raise ConfigurationError(msg)
-
-        pk_columns = {c.name for c in self._table.primary_key.columns}
-
-        if not pk_columns:
-            msg = f"Table '{self._table_name}' has no primary key defined"
-            raise ConfigurationError(msg)
-
-        provided = set(pk.keys())
-
-        invalid = provided - pk_columns
-        if invalid:
-            msg = (
-                f"Columns {sorted(invalid)} are not part of the primary key. "
-                f"Primary key columns: {sorted(pk_columns)}"
-            )
-            raise ConfigurationError(msg)
-
-        missing = pk_columns - provided
-        if missing:
-            msg = (
-                f"Incomplete primary key: missing columns {sorted(missing)}. "
-                f"All primary key columns required: {sorted(pk_columns)}"
-            )
-            raise ConfigurationError(msg)
+        validate_pk_columns(self._table, self._table_name, pk)

--- a/src/azure_functions_db/binding/writer.py
+++ b/src/azure_functions_db/binding/writer.py
@@ -15,6 +15,7 @@ from ..core.config import DbConfig, resolve_env_vars
 from ..core.engine import EngineProvider
 from ..core.errors import ConfigurationError, DbConnectionError, WriteError
 from ..core.metadata import get_metadata_cache
+from ..core.validation import validate_pk_columns
 
 logger = logging.getLogger(__name__)
 
@@ -447,34 +448,7 @@ class DbWriter:
     def _validate_pk_columns(self, pk: dict[str, object]) -> None:
         """Validate that *pk* keys exactly match the table's primary key columns."""
         assert self._table is not None  # noqa: S101  # nosec B101
-
-        if not pk:
-            msg = "pk must not be empty"
-            raise ConfigurationError(msg)
-
-        pk_columns = {c.name for c in self._table.primary_key.columns}
-
-        if not pk_columns:
-            msg = f"Table '{self._table_name}' has no primary key defined"
-            raise ConfigurationError(msg)
-
-        provided = set(pk.keys())
-
-        invalid = provided - pk_columns
-        if invalid:
-            msg = (
-                f"Columns {sorted(invalid)} are not part of the primary key. "
-                f"Primary key columns: {sorted(pk_columns)}"
-            )
-            raise ConfigurationError(msg)
-
-        missing = pk_columns - provided
-        if missing:
-            msg = (
-                f"Incomplete primary key: missing columns {sorted(missing)}. "
-                f"All primary key columns required: {sorted(pk_columns)}"
-            )
-            raise ConfigurationError(msg)
+        validate_pk_columns(self._table, self._table_name, pk)
 
     def _validate_conflict_columns(self, conflict_columns: list[str]) -> None:
         assert self._table is not None  # noqa: S101  # nosec B101

--- a/src/azure_functions_db/core/validation.py
+++ b/src/azure_functions_db/core/validation.py
@@ -1,0 +1,48 @@
+"""Shared validation helpers for database binding primary-key handling."""
+
+from __future__ import annotations
+
+from sqlalchemy.schema import Table
+
+from .errors import ConfigurationError
+
+
+def validate_pk_columns(table: Table, table_name: str | None, pk: dict[str, object]) -> None:
+    """Validate that *pk* keys exactly match *table*'s primary key columns.
+
+    Args:
+        table: The reflected SQLAlchemy ``Table`` to validate against.
+        table_name: The table name, used only for error messages.
+        pk: The provided primary-key mapping to validate.
+
+    Raises:
+        ConfigurationError: If *pk* is empty, the table has no primary key, or
+            the provided keys do not exactly match the primary-key columns.
+    """
+    if not pk:
+        msg = "pk must not be empty"
+        raise ConfigurationError(msg)
+
+    pk_columns = {c.name for c in table.primary_key.columns}
+
+    if not pk_columns:
+        msg = f"Table '{table_name}' has no primary key defined"
+        raise ConfigurationError(msg)
+
+    provided = set(pk.keys())
+
+    invalid = provided - pk_columns
+    if invalid:
+        msg = (
+            f"Columns {sorted(invalid)} are not part of the primary key. "
+            f"Primary key columns: {sorted(pk_columns)}"
+        )
+        raise ConfigurationError(msg)
+
+    missing = pk_columns - provided
+    if missing:
+        msg = (
+            f"Incomplete primary key: missing columns {sorted(missing)}. "
+            f"All primary key columns required: {sorted(pk_columns)}"
+        )
+        raise ConfigurationError(msg)

--- a/tests/test_shared_core.py
+++ b/tests/test_shared_core.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 import threading
-from typing import cast
+from typing import Any, cast
 from uuid import uuid4
 
 import pytest
@@ -18,6 +18,7 @@ from azure_functions_db.core.engine import EngineProvider
 from azure_functions_db.core.errors import ConfigurationError, CursorSerializationError, DbError
 from azure_functions_db.core.serializers import parse_checkpoint_cursor, serialize_cursor_part
 from azure_functions_db.core.types import RawRecord, Row, RowDict
+from azure_functions_db.core.validation import validate_pk_columns
 from azure_functions_db.state.errors import StateStoreError
 from azure_functions_db.trigger.errors import PollerError
 
@@ -367,3 +368,40 @@ def test_sqlalchemy_source_uses_engine_provider(tmp_path: Path) -> None:
 
     assert count == 2
     provider.dispose_all()
+
+
+def _pk_table(*pk_names: str) -> Table:
+    metadata = MetaData()
+    columns: list[Column[Any]] = [
+        Column(name, Integer, primary_key=True) for name in pk_names
+    ]
+    columns.append(Column("data", String(10)))
+    return Table("widgets", metadata, *columns)
+
+
+class TestValidatePkColumns:
+    """Shared primary-key validation used by both DbReader and DbWriter."""
+
+    def test_valid_single_pk_passes(self) -> None:
+        validate_pk_columns(_pk_table("id"), "widgets", {"id": 1})
+
+    def test_valid_composite_pk_passes(self) -> None:
+        validate_pk_columns(_pk_table("a", "b"), "widgets", {"a": 1, "b": 2})
+
+    def test_empty_pk_raises(self) -> None:
+        with pytest.raises(ConfigurationError, match="pk must not be empty"):
+            validate_pk_columns(_pk_table("id"), "widgets", {})
+
+    def test_no_primary_key_raises(self) -> None:
+        metadata = MetaData()
+        table = Table("widgets", metadata, Column("data", String(10)))
+        with pytest.raises(ConfigurationError, match="has no primary key defined"):
+            validate_pk_columns(table, "widgets", {"data": "x"})
+
+    def test_invalid_columns_raises(self) -> None:
+        with pytest.raises(ConfigurationError, match="are not part of the primary key"):
+            validate_pk_columns(_pk_table("id"), "widgets", {"bogus": 1})
+
+    def test_incomplete_composite_pk_raises(self) -> None:
+        with pytest.raises(ConfigurationError, match="Incomplete primary key"):
+            validate_pk_columns(_pk_table("a", "b"), "widgets", {"a": 1})


### PR DESCRIPTION
## Summary
Delivers the safe, byte-identical de-duplication portion of the *"Unify triplicated init/reflect/validate lifecycle"* item from the #196 tracker.

`DbReader._validate_pk_columns` and `DbWriter._validate_pk_columns` were **byte-identical** (same logic, same error messages). This extracts that logic into a single shared free function.

## Changes
- Add `core/validation.py` with `validate_pk_columns(table, table_name, pk)` — the single source of truth for primary-key validation.
- `DbReader` and `DbWriter` keep thin `_validate_pk_columns` methods that assert the table is reflected and delegate to the shared helper, preserving all internal call sites and exact error messages.
- Add focused unit tests for the shared helper (valid single/composite PK, empty pk, no-PK table, invalid columns, incomplete composite PK).

## Scope note
This is the low-risk, fully behavior-preserving slice of the reflect/validate lifecycle item. The broader `ReflectMixin` / `ensure_table_reflected` extraction and `_reflect_table` unification (whose implementations differ slightly between reader and writer) are intentionally deferred to a separate focused PR.

## Verification
- `make lint`, `make typecheck` clean.
- `make test`: 611 passed, coverage **95.31%** (gate 95%). All error messages unchanged.

Part of #196
Part of #188