### PR TITLE
docs: sync i18n async wording and add docs-drift guard

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -274,6 +274,12 @@ def orders_poll(timer: func.TimerRequest, events: list[RowChange], out: DbOut) -
 
 完全に実行可能なサンプルは [`examples/trigger_with_binding/`](examples/trigger_with_binding/) を参照してください。
 
+## 非同期ハンドラー
+
+`async def` ハンドラーがサポートされています。`azure-functions-db` 内部の SQLAlchemy 操作は同期的に実行され、`async` ハンドラーがバインディング（入力取得、`DbOut.set(...)`、ポーリングコミットなど）を呼び出すと、パッケージは `asyncio.to_thread` を介してブロッキング呼び出しをワーカースレッドにオフロードするため、イベントループはブロックされません。
+
+> **例外 — `@db.trigger` は非同期ハンドラーをサポートしません。** `PollTrigger.run()` が同期的に動作するため、`trigger` デコレーターはデコレーション時に `ConfigurationError` を送出して非同期ハンドラーを拒否します。さらに `PollTrigger.run()` は防御的なランタイムガードとして、非同期の呼び出し可能オブジェクトが渡された場合に `TypeError` を送出します。`@db.trigger` には同期ハンドラーを使用してください。
+
 ## Supported Databases
 
 | Database | Extra | Driver |

--- a/README.ko.md
+++ b/README.ko.md
@@ -274,6 +274,12 @@ def orders_poll(timer: func.TimerRequest, events: list[RowChange], out: DbOut) -
 
 전체 실행 예제는 [`examples/trigger_with_binding/`](examples/trigger_with_binding/)를 참고하세요.
 
+## 비동기 핸들러
+
+`async def` 핸들러가 지원됩니다. `azure-functions-db` 내부의 SQLAlchemy 작업은 동기 방식으로 실행되며, `async` 핸들러가 바인딩(입력 조회, `DbOut.set(...)`, 폴링 커밋 등)을 호출하면 패키지가 `asyncio.to_thread`를 통해 블로킹 호출을 워커 스레드로 오프로드하므로 이벤트 루프가 막히지 않습니다.
+
+> **예외 — `@db.trigger`는 비동기 핸들러를 지원하지 않습니다.** `PollTrigger.run()`이 동기 방식으로 동작하기 때문에, `trigger` 데코레이터는 데코레이션 시점에 `ConfigurationError`를 발생시켜 비동기 핸들러를 거부합니다. 또한 `PollTrigger.run()`은 방어적 런타임 가드로서 비동기 콜러블이 전달되면 `TypeError`를 발생시킵니다. `@db.trigger`에는 동기 핸들러를 사용하세요.
+
 ## 지원 데이터베이스
 
 | Database | Extra | Driver |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -274,6 +274,12 @@ def orders_poll(timer: func.TimerRequest, events: list[RowChange], out: DbOut) -
 
 完整可运行示例见 [`examples/trigger_with_binding/`](examples/trigger_with_binding/)。
 
+## 异步处理器
+
+支持 `async def` 处理器。`azure-functions-db` 内部的 SQLAlchemy 操作以同步方式运行；当 `async` 处理器调用绑定（输入获取、`DbOut.set(...)`、轮询提交等）时，该包会通过 `asyncio.to_thread` 将阻塞调用卸载到工作线程，因此事件循环不会被阻塞。
+
+> **例外 —— `@db.trigger` 不支持异步处理器。** 由于 `PollTrigger.run()` 是同步的，`trigger` 装饰器会在装饰时抛出 `ConfigurationError` 以拒绝异步处理器；此外 `PollTrigger.run()` 作为防御性运行时保护，在被传入异步可调用对象时会抛出 `TypeError`。请为 `@db.trigger` 使用同步处理器。
+
 ## Supported Databases
 
 | Database | Extra | Driver |

--- a/tests/test_docs_i18n_async_drift.py
+++ b/tests/test_docs_i18n_async_drift.py
@@ -1,0 +1,55 @@
+"""Guards against drift between the English README's async-handler rejection
+wording and its translated counterparts in the i18n READMEs.
+
+The English README documents an important behavioral contract: ``@db.trigger``
+rejects async handlers at decoration time by raising ``ConfigurationError``, and
+``PollTrigger.run()`` additionally raises ``TypeError`` as a defensive runtime
+guard. That contract is asserted in code by
+``tests/test_decorator.py::test_trigger_async_handler_rejected`` (the
+``ConfigurationError`` path) and
+``tests/test_poll_trigger.py::test_run_rejects_async_handler`` /
+``test_async_handler_callable_object`` (the ``TypeError`` path).
+
+The translated READMEs must not silently omit this exception note. This test
+fails CI whenever an i18n README stops mentioning both documented exception
+types near an async-handler discussion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Translated READMEs that must carry the async-rejection wording.
+_I18N_READMES = ("README.ko.md", "README.ja.md", "README.zh-CN.md")
+
+# The documented exception types are code identifiers, so they appear verbatim
+# in every language variant.
+_REQUIRED_TOKENS = ("ConfigurationError", "TypeError", "@db.trigger")
+
+
+def test_i18n_readmes_document_async_rejection() -> None:
+    offenders: list[str] = []
+
+    for name in _I18N_READMES:
+        path = _REPO_ROOT / name
+        assert path.exists(), f"missing i18n README: {name}"
+        text = path.read_text(encoding="utf-8")
+        missing = [token for token in _REQUIRED_TOKENS if token not in text]
+        if missing:
+            offenders.append(f"{name}: missing {missing}")
+
+    assert not offenders, (
+        "i18n README(s) dropped the async-handler rejection wording "
+        "(ConfigurationError at decoration, TypeError from PollTrigger.run):\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_english_readme_documents_async_rejection() -> None:
+    # Sanity check: the guard above is only meaningful if the English source of
+    # truth still carries the wording it expects translations to mirror.
+    text = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    for token in _REQUIRED_TOKENS:
+        assert token in text, f"English README missing async-rejection token: {token}"


### PR DESCRIPTION
## Summary
- Propagate the async-handler rejection contract into the **ko / ja / zh-CN** READMEs (they previously had **no** async-handler documentation): `@db.trigger` rejects async handlers at decoration time via `ConfigurationError`, and `PollTrigger.run()` raises `TypeError` as a defensive runtime guard.
- Add `tests/test_docs_i18n_async_drift.py` — fails CI if any translated README drops the documented exception wording (mirrors the existing `test_docs_pip_install_drift.py` pattern).

## Acceptance checklist (#192)
- [x] **i18n async-behavior wording sync** — ko/ja/zh-CN now carry the async-rejection note.
- [x] **Docs-drift CI guard + async-rejection exception-type unit test** — the pip-install drift guard already ships (`test_docs_pip_install_drift.py`); the exception-type assertions already exist (`test_trigger_async_handler_rejected` → `ConfigurationError`, `test_run_rejects_async_handler` / `test_async_handler_callable_object` → `TypeError`); this PR adds the i18n-wording drift guard.

## Validation
- `make lint`, `make typecheck` clean.
- `hatch run pytest --cov` — all pass, coverage **95.31%** (≥95%).

Closes #192