### PR TITLE
docs: add SQL Server poll-trigger docker-compose example

### DIFF
--- a/examples/mssql-poll-trigger/README.md
+++ b/examples/mssql-poll-trigger/README.md
@@ -1,0 +1,226 @@
+# SQL Server polling-trigger example
+
+End-to-end runnable example for `azure-functions-db`'s poll-based pseudo
+trigger against **SQL Server**, with checkpoints stored in
+[Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite)
+(the local Azure Storage emulator).
+
+The example polls an `orders` table on a one-minute timer, treats each row
+change as an event, and writes an idempotent projection into a
+`processed_orders` table on every tick.
+
+> **SQL Server has no supported upsert path** in this package (upsert is
+> available for PostgreSQL, SQLite, and MySQL only). This example therefore
+> uses `@db.inject_writer` + a plain `insert`, swallowing the primary-key
+> violation that a replay produces — the documented
+> [*"when upsert is not available"*](../postgresql-poll-trigger/README.md#when-upsert-is-not-available)
+> fallback. See `function_app.py`.
+
+> For production **AAD / managed-identity** authentication instead of the SQL
+> username/password used here, see the companion example
+> [`examples/managed-identity-mssql/`](../managed-identity-mssql/).
+
+---
+
+## What you get
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` | SQL Server 2022 + Azurite for the checkpoint store |
+| `schema.sql` | `dbo.orders` source table (with a monotonic `updated_at` cursor and trigger), plus `dbo.processed_orders` projection |
+| `function_app.py` | A timer-driven `@db.trigger` polling `orders`, writing into `processed_orders` via `@db.inject_writer` |
+| `host.json` | Functions host config |
+| `local.settings.json.example` | All required environment variables |
+| `requirements.txt` | Function App dependencies |
+
+---
+
+## Prerequisites
+
+- Docker + Docker Compose
+- Python 3.10+
+- [Azure Functions Core Tools v4](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
+  (`func` CLI)
+- **Microsoft ODBC Driver 18 for SQL Server** on the host running the Function
+  App (the `pyodbc` wheel does not bundle it):
+  - Linux: <https://learn.microsoft.com/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server>
+  - Windows: install the "ODBC Driver 18 for SQL Server" MSI.
+
+### ARM / Apple Silicon note
+
+`mcr.microsoft.com/mssql/server:2022-latest` is an **x86_64** image. On ARM
+hosts either enable Docker Desktop's Rosetta emulation
+(Settings → General → *"Use Rosetta for x86/amd64 emulation"*; the compose file
+already pins `platform: linux/amd64`), or substitute an ARM-friendly,
+mostly-T-SQL-compatible image such as
+`mcr.microsoft.com/azure-sql-edge:latest`.
+
+### Licensing
+
+The container runs the free **Developer** edition (`MSSQL_PID=Developer`), which
+is licensed for development and testing only — not production.
+
+---
+
+## Connection string format
+
+`SOURCE_DB_URL` / `DEST_DB_URL` use the SQLAlchemy `mssql+pyodbc` dialect with
+the ODBC driver selected via a query parameter:
+
+```
+mssql+pyodbc://sa:Str0ng_Passw0rd1@localhost:1433/app?driver=ODBC+Driver+18+for+SQL+Server&Encrypt=yes&TrustServerCertificate=yes
+```
+
+- `driver=ODBC+Driver+18+for+SQL+Server` — must match the installed driver name.
+- `Encrypt=yes` — Driver 18 encrypts by default.
+- `TrustServerCertificate=yes` — accepts the container's self-signed cert (local
+  dev only; drop it against a real server with a trusted certificate).
+- URL-encode any special characters in the password (`@`, `:`, `/`, `?`).
+
+---
+
+## End-to-end run
+
+### 1. Start SQL Server and Azurite
+
+```bash
+cd examples/mssql-poll-trigger
+docker compose up -d
+```
+
+Wait until both containers report healthy:
+
+```bash
+docker compose ps
+```
+
+### 2. Create the database and schema
+
+The container starts with only the system databases, so create `app` first:
+
+```bash
+docker exec -i afdb-mssql /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P "Str0ng_Passw0rd1" -C \
+  -Q "IF DB_ID('app') IS NULL CREATE DATABASE app;"
+
+docker exec -i afdb-mssql /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P "Str0ng_Passw0rd1" -C -d app < schema.sql
+```
+
+### 3. Configure local settings
+
+```bash
+cp local.settings.json.example local.settings.json
+```
+
+The defaults already point at the docker-compose services and Azurite — no
+edits are needed for the happy-path local run.
+
+### 4. Install dependencies
+
+```bash
+python -m venv .venv
+source .venv/bin/activate     # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+Make sure ODBC Driver 18 is installed (see Prerequisites).
+
+### 5. Run the Function App
+
+```bash
+func start
+```
+
+`orders_poll` registers as a Timer trigger firing every minute.
+
+### 6. Insert / update rows in `orders`
+
+In another terminal:
+
+```bash
+docker exec -i afdb-mssql /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P "Str0ng_Passw0rd1" -C -d app -Q "
+    INSERT INTO dbo.orders (customer_name, amount, status)
+    VALUES (N'Alice', 99.99, N'pending'), (N'Bob', 49.50, N'pending');
+"
+# Wait for the next tick, then update one row to produce another event.
+docker exec -i afdb-mssql /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P "Str0ng_Passw0rd1" -C -d app -Q "
+    UPDATE dbo.orders SET status = N'shipped', amount = 109.99
+     WHERE customer_name = N'Alice';
+"
+```
+
+### 7. Observe events
+
+Verify the projection table:
+
+```bash
+docker exec -i afdb-mssql /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P "Str0ng_Passw0rd1" -C -d app -Q "
+    SELECT order_id, source_cursor, customer_name, amount, status
+      FROM dbo.processed_orders ORDER BY order_id, source_cursor;"
+```
+
+You should see one row per delivered event — the initial insert produces one
+row, and the subsequent `UPDATE` produces another row with the same `order_id`
+but a later `source_cursor`.
+
+### 8. Tear down
+
+```bash
+docker compose down -v   # -v also removes the SQL Server + Azurite volumes
+```
+
+---
+
+## Cursor column choice
+
+The example uses `updated_at DATETIME2(3) NOT NULL` as the cursor column,
+maintained by an `AFTER INSERT, UPDATE` trigger (`orders_set_updated_at` in
+`schema.sql`). SQL Server runs with `RECURSIVE_TRIGGERS` **OFF** by default, so
+the trigger's own `UPDATE` of the same table does not re-fire it. This satisfies
+the framework's source preconditions:
+
+- **Monotonically non-decreasing** — every insert and update sets `updated_at`
+  to `SYSUTCDATETIME()`.
+- **Stable PK / total ordering** — `(updated_at, id)` is ordered via
+  `pk_columns=["id"]` as the tiebreaker.
+
+> If your real schema mutates rows without touching a cursor column you will
+> silently miss updates. Always pick a column bumped on **every** mutation you
+> care about. See [Semantics §4 — Delete Semantics](../../docs/03-semantics.md#4-delete-semantics).
+
+## Idempotent handler pattern (no upsert)
+
+Because SQL Server upsert is unsupported here, `function_app.py` uses
+`@db.inject_writer` and `writer.insert(...)` per event into a
+`processed_orders` table whose primary key is `(order_id, source_cursor)`. The
+polling trigger is at-least-once, so the same `RowChange` may be redelivered
+(see [§4 Duplicate Window Reference](../../docs/24-polling-runtime-semantics.md#4-duplicate-window-reference)).
+A replay re-inserts the same composite key, raising a `WriteError` whose cause
+is a SQLAlchemy `IntegrityError`; the handler swallows exactly that case as an
+idempotent no-op and re-raises any other failure.
+
+### When latest-state projection is what you want
+
+If you only need the current state per `order_id` (last write wins), key the
+destination table on `order_id` alone and use `writer.update(...)` /
+`writer.insert(...)` accordingly — but be aware an out-of-order replay of an
+older event can overwrite a newer projection.
+
+## Checkpoint container configuration
+
+`function_app.py` builds a `BlobCheckpointStore` against the container
+`db-state` in the storage account named by `AzureWebJobsStorage`. Azurite
+creates the container on first use. In production, pre-create it with the
+minimal RBAC needed (Storage Blob Data Contributor on that container only) — see
+[Checkpoint / Lease Spec §12](../../docs/06-checkpoint-lease-spec.md#12-operational-guidelines).
+
+## Tuning notes
+
+The example uses the package defaults — `batch_size=100`,
+`max_batches_per_tick=1`, `lease_ttl_seconds=120`, timer schedule
+`0 */1 * * * *` (every minute). For production sizing rules see
+[Polling Runtime §7](../../docs/24-polling-runtime-semantics.md#7-tuning-lease_ttl_seconds-and-timer-interval).

--- a/examples/mssql-poll-trigger/docker-compose.yml
+++ b/examples/mssql-poll-trigger/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+  mssql:
+    # SQL Server 2022 is an x86_64 image. On Apple Silicon / ARM hosts either
+    # enable Docker Desktop's Rosetta emulation (Settings > General > "Use
+    # Rosetta") or switch to an ARM-friendly alternative such as
+    # mcr.microsoft.com/azure-sql-edge:latest (mostly T-SQL compatible).
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    platform: linux/amd64
+    container_name: afdb-mssql
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Str0ng_Passw0rd1"
+      MSSQL_PID: "Developer"
+    ports:
+      - "1433:1433"
+    volumes:
+      - mssqldata:/var/opt/mssql
+    healthcheck:
+      # /opt/mssql-tools18 ships with the 2022 image; -C trusts the self-signed cert.
+      test:
+        - CMD-SHELL
+        - >-
+          /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa
+          -P "$$MSSQL_SA_PASSWORD" -C -Q "SELECT 1" || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:latest
+    container_name: afdb-azurite
+    command: >
+      azurite
+      --blobHost 0.0.0.0
+      --queueHost 0.0.0.0
+      --tableHost 0.0.0.0
+      --location /data
+      --skipApiVersionCheck
+    ports:
+      - "10000:10000"   # Blob
+      - "10001:10001"   # Queue
+      - "10002:10002"   # Table
+    volumes:
+      - azurite-data:/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - 'node -e "require(''net'').createConnection(10000, ''127.0.0.1'').on(''connect'', () => process.exit(0)).on(''error'', () => process.exit(1))"'
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  mssqldata:
+  azurite-data:

--- a/examples/mssql-poll-trigger/function_app.py
+++ b/examples/mssql-poll-trigger/function_app.py
@@ -1,0 +1,135 @@
+"""SQL Server polling-trigger example.
+
+This Function App polls a SQL Server ``dbo.orders`` table every minute via
+``@db.trigger`` and writes a strictly-idempotent event projection into
+``dbo.processed_orders``.
+
+Unlike the PostgreSQL / MySQL examples, **SQL Server has no supported upsert
+path** in this package (upsert is available for PostgreSQL, SQLite, and MySQL
+only). So instead of ``@db.output(action="upsert", ...)`` this example uses
+``@db.inject_writer`` and performs a plain ``insert`` per event, swallowing the
+primary-key violation that a *replay* of an already-processed event produces.
+This is the documented "when upsert is not available" fallback — the composite
+primary key ``(order_id, source_cursor)`` makes a redelivery collide on the
+exact same row, so the swallowed ``IntegrityError`` is a true no-op.
+
+For production AAD / managed-identity authentication (instead of the SQL
+username/password used here for local dev), see the companion example
+``examples/managed-identity-mssql/``.
+
+Required environment variables (see local.settings.json.example):
+
+- AzureWebJobsStorage  Connection string for the checkpoint blob container.
+                       Defaults to Azurite (``UseDevelopmentStorage=true``).
+- SOURCE_DB_URL        SQLAlchemy mssql+pyodbc URL for the source database.
+- DEST_DB_URL          SQLAlchemy mssql+pyodbc URL for the destination. May be
+                       the same database; the bindings share an
+                       ``EngineProvider`` so the connection pool is reused.
+
+Delivery is at-least-once; see docs/24-polling-runtime-semantics.md.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import os
+
+import azure.functions as func
+from azure.storage.blob import ContainerClient
+from sqlalchemy.exc import IntegrityError
+
+from azure_functions_db import (
+    BlobCheckpointStore,
+    DbBindings,
+    DbWriter,
+    EngineProvider,
+    RowChange,
+    SqlAlchemySource,
+    WriteError,
+)
+
+app = func.FunctionApp()
+db = DbBindings()
+
+# Module-level EngineProvider so the source and the writer share a single
+# SQLAlchemy engine (and connection pool) per worker process.
+engine_provider = EngineProvider()
+
+# ``updated_at`` is maintained by an AFTER INSERT, UPDATE trigger in schema.sql
+# so it is refreshed on every mutation. The framework appends ``id`` as the
+# tiebreaker via ``pk_columns`` to give a total ordering.
+source = SqlAlchemySource(
+    url="%SOURCE_DB_URL%",
+    table="orders",
+    schema="dbo",
+    cursor_column="updated_at",
+    pk_columns=["id"],
+    engine_provider=engine_provider,
+)
+
+# ``%VAR%`` placeholder syntax is resolved by this package for its own ``url=``
+# arguments; the Azure Storage SDK does not perform that substitution, so we
+# read the connection string from the environment directly here.
+checkpoint_store = BlobCheckpointStore(
+    container_client=ContainerClient.from_connection_string(
+        conn_str=os.environ["AzureWebJobsStorage"],
+        container_name="db-state",
+    ),
+    source_fingerprint=source.source_descriptor.fingerprint,
+)
+
+
+@app.function_name(name="orders_poll")
+@app.schedule(schedule="0 */1 * * * *", arg_name="timer", use_monitor=True)
+@db.trigger(arg_name="events", source=source, checkpoint_store=checkpoint_store)
+@db.inject_writer(
+    "writer",
+    url="%DEST_DB_URL%",
+    table="processed_orders",
+    schema="dbo",
+    engine_provider=engine_provider,
+)
+def orders_poll(
+    timer: func.TimerRequest,
+    events: list[RowChange],
+    writer: DbWriter,
+) -> None:
+    """Project ``orders`` row changes into ``processed_orders``.
+
+    Each projection row is keyed by ``(order_id, source_cursor)`` —
+    i.e. ``(event.pk["id"], event.cursor[0])``. A replay of the same
+    ``RowChange`` re-inserts the same composite key, so the resulting
+    primary-key ``IntegrityError`` is swallowed and the write is a no-op.
+    Any other write failure is re-raised so the batch is retried.
+    """
+    del timer
+
+    if not events:
+        return
+
+    # ``event.cursor`` is aligned with the source's ``(cursor_column, *pk)``
+    # ordering — here ``(updated_at, id)``. Element 0 is the source-side change
+    # timestamp we persist as ``source_cursor``; ``processed_at`` is our own
+    # observation wall-clock time.
+    processed_at = datetime.now(timezone.utc)
+
+    for event in events:
+        if event.after is None:
+            continue
+        row = {
+            "order_id": event.pk["id"],
+            "source_cursor": event.cursor[0],
+            "customer_name": event.after["customer_name"],
+            "amount": event.after["amount"],
+            "status": event.after["status"],
+            "processed_at": processed_at,
+        }
+        try:
+            writer.insert(data=row)
+        except WriteError as exc:
+            # A duplicate (order_id, source_cursor) means this event was already
+            # projected on an earlier delivery — an idempotent no-op. Re-raise
+            # anything that is not a primary-key / unique violation.
+            if isinstance(exc.__cause__, IntegrityError):
+                continue
+            raise

--- a/examples/mssql-poll-trigger/host.json
+++ b/examples/mssql-poll-trigger/host.json
@@ -1,0 +1,11 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  }
+}

--- a/examples/mssql-poll-trigger/local.settings.json.example
+++ b/examples/mssql-poll-trigger/local.settings.json.example
@@ -1,0 +1,9 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "SOURCE_DB_URL": "mssql+pyodbc://sa:Str0ng_Passw0rd1@localhost:1433/app?driver=ODBC+Driver+18+for+SQL+Server&Encrypt=yes&TrustServerCertificate=yes",
+    "DEST_DB_URL": "mssql+pyodbc://sa:Str0ng_Passw0rd1@localhost:1433/app?driver=ODBC+Driver+18+for+SQL+Server&Encrypt=yes&TrustServerCertificate=yes"
+  }
+}

--- a/examples/mssql-poll-trigger/requirements.txt
+++ b/examples/mssql-poll-trigger/requirements.txt
@@ -1,0 +1,2 @@
+azure-functions
+azure-functions-db[mssql]

--- a/examples/mssql-poll-trigger/schema.sql
+++ b/examples/mssql-poll-trigger/schema.sql
@@ -1,0 +1,62 @@
+-- SQL Server schema for the poll-trigger example.
+--
+-- Run against a database named `app` (see README for `CREATE DATABASE app`).
+-- `GO` batch separators are sqlcmd directives; if you apply this file with a
+-- different client, split on `GO` or execute each batch separately.
+
+-- Source table polled by the @db.trigger.
+-- The cursor column is `updated_at`; an AFTER INSERT, UPDATE trigger
+-- guarantees it is refreshed to the current UTC time on every mutation.
+-- SQL Server runs with RECURSIVE_TRIGGERS OFF by default, so the trigger's
+-- own UPDATE does not re-fire the trigger.
+IF OBJECT_ID('dbo.orders', 'U') IS NULL
+CREATE TABLE dbo.orders (
+    id            BIGINT IDENTITY(1, 1) PRIMARY KEY,
+    customer_name NVARCHAR(200)  NOT NULL,
+    amount        DECIMAL(12, 2) NOT NULL,
+    status        NVARCHAR(50)   NOT NULL
+        CONSTRAINT DF_orders_status DEFAULT 'pending',
+    created_at    DATETIME2(3)   NOT NULL
+        CONSTRAINT DF_orders_created_at DEFAULT SYSUTCDATETIME(),
+    updated_at    DATETIME2(3)   NOT NULL
+        CONSTRAINT DF_orders_updated_at DEFAULT SYSUTCDATETIME()
+);
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes WHERE name = 'orders_updated_at_id_idx'
+      AND object_id = OBJECT_ID('dbo.orders')
+)
+CREATE INDEX orders_updated_at_id_idx ON dbo.orders (updated_at, id);
+GO
+
+CREATE OR ALTER TRIGGER dbo.orders_set_updated_at
+    ON dbo.orders
+    AFTER INSERT, UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE o
+       SET updated_at = SYSUTCDATETIME()
+      FROM dbo.orders o
+      INNER JOIN inserted i ON o.id = i.id;
+END;
+GO
+
+-- Strictly-idempotent destination table.
+-- The composite primary key (order_id, source_cursor) makes a replay of the
+-- same RowChange (at-least-once delivery) collide on the exact same row, so
+-- the handler can treat the resulting primary-key violation as a no-op.
+-- Keying on order_id alone would be a latest-state projection: an out-of-order
+-- replay of an older event could overwrite a newer state.
+IF OBJECT_ID('dbo.processed_orders', 'U') IS NULL
+CREATE TABLE dbo.processed_orders (
+    order_id      BIGINT         NOT NULL,
+    source_cursor DATETIME2(3)   NOT NULL,
+    customer_name NVARCHAR(200)  NOT NULL,
+    amount        DECIMAL(12, 2) NOT NULL,
+    status        NVARCHAR(50)   NOT NULL,
+    processed_at  DATETIME2(3)   NOT NULL,
+    CONSTRAINT PK_processed_orders PRIMARY KEY (order_id, source_cursor)
+);
+GO


### PR DESCRIPTION
## Summary
Add `examples/mssql-poll-trigger/` — an end-to-end runnable poll-trigger example against **SQL Server** with Azurite for checkpoints.

Because SQL Server has no supported upsert path in this package (upsert is PostgreSQL/SQLite/MySQL only), the handler uses `@db.inject_writer` + `insert` into a `(order_id, source_cursor)`-keyed table and swallows the primary-key `IntegrityError` on replay — the documented *"when upsert is not available"* idempotency fallback.

## Acceptance checklist (#106)
- [x] `examples/mssql-poll-trigger/` directory
- [x] `docker-compose.yml` with `mcr.microsoft.com/mssql/server` + Azurite (ARM/Rosetta + azure-sql-edge notes)
- [x] `schema.sql` with a sample table and a monotonic cursor column (`updated_at` via AFTER INSERT/UPDATE trigger)
- [x] `local.settings.json.example` with all required env vars
- [x] `function_app.py` demonstrating `SqlAlchemySource` + `BlobCheckpointStore` + a timer-driven `@db.trigger`
- [x] `README.md` with end-to-end run steps and ARM / licensing notes
- [x] ODBC Driver 18 install + `mssql+pyodbc` connection-string format documented
- [x] Cross-links the Managed Identity example (#104)

## Validation
- `make lint`, `make typecheck` clean; example passes `py_compile` + `ruff`.
- Docs-drift guard tests pass.

Closes #106