### PR TITLE
refactor(metadata): type the db cross-package metadata contract

### DIFF
--- a/src/azure_functions_db/_metadata.py
+++ b/src/azure_functions_db/_metadata.py
@@ -1,0 +1,90 @@
+"""Typed cross-package metadata contract for the ``db`` namespace.
+
+This module defines the shape of the ``_azure_functions_metadata`` convention
+attribute that decorators attach to Azure Functions handlers. Consumers (such as
+the OpenAPI bridge) read this attribute to discover database bindings and
+injections without importing this package.
+
+The contract is behavior-preserving: the payload shape (``version``,
+``bindings``, ``injections``) is unchanged from the historical ad-hoc dict.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict, cast
+
+# Convention attribute name shared across every Azure Functions toolkit package.
+METADATA_ATTR = "_azure_functions_metadata"
+
+# Namespace owned by this package inside the convention attribute.
+NAMESPACE = "db"
+
+# Version of the ``db`` namespace payload. Consumers should read this and
+# degrade gracefully when it exceeds the version they support.
+DB_METADATA_VERSION = 1
+
+
+class _BindingRequired(TypedDict):
+    """Keys present on every binding entry."""
+
+    kind: str
+    parameter: str
+
+
+class BindingEntry(_BindingRequired, total=False):
+    """A single database binding (trigger/input/output).
+
+    ``connection_setting`` and ``resource`` are only present for output-style
+    bindings.
+    """
+
+    connection_setting: str
+    resource: dict[str, Any]
+
+
+class InjectionEntry(TypedDict):
+    """A single reader/writer injection into a handler parameter."""
+
+    kind: str
+    parameter: str
+
+
+class DbMetadata(TypedDict):
+    """The ``db`` namespace payload stored under ``METADATA_ATTR``."""
+
+    version: int
+    bindings: list[BindingEntry]
+    injections: list[InjectionEntry]
+
+
+def merge_db_metadata(fn: Any, payload: DbMetadata) -> None:
+    """Merge a ``db`` payload into the convention attribute on ``fn``.
+
+    Preserves other namespaces and concatenates ``bindings``/``injections``
+    when the handler already carries ``db`` metadata (multiple decorators).
+    """
+    existing: Any = getattr(fn, METADATA_ATTR, {})
+    if not isinstance(existing, dict):
+        existing = {}
+
+    ns_meta = existing.get(NAMESPACE)
+    if isinstance(ns_meta, dict):
+        merged: dict[str, Any] = {**payload}
+        merged["bindings"] = list(ns_meta.get("bindings", [])) + list(payload["bindings"])
+        merged["injections"] = list(ns_meta.get("injections", [])) + list(payload["injections"])
+        existing = {**existing, NAMESPACE: merged}
+    else:
+        existing = {**existing, NAMESPACE: dict(payload)}
+
+    setattr(fn, METADATA_ATTR, existing)
+
+
+def read_db_metadata(func: Any) -> DbMetadata | None:
+    """Return the typed ``db`` metadata attached to ``func``, or ``None``."""
+    meta = getattr(func, METADATA_ATTR, None)
+    if not isinstance(meta, dict):
+        return None
+    entry = meta.get(NAMESPACE)
+    if not isinstance(entry, dict):
+        return None
+    return cast("DbMetadata", entry)

--- a/src/azure_functions_db/decorator.py
+++ b/src/azure_functions_db/decorator.py
@@ -7,10 +7,17 @@ from contextlib import asynccontextmanager
 import functools
 import inspect
 import logging
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel
 
+from ._metadata import (
+    METADATA_ATTR,
+    NAMESPACE,
+    DbMetadata,
+    merge_db_metadata,
+    read_db_metadata,
+)
 from .binding.reader import DbReader
 from .binding.writer import DbWriter
 from .core.engine import EngineProvider
@@ -26,7 +33,7 @@ logger = logging.getLogger(__name__)
 # Parameter names reserved by Azure Functions runtime.
 _RESERVED_ARGS = frozenset({"timer", "req", "context", "msg", "input", "output"})
 _DB_DECORATOR_ATTR = "_db_decorators"
-_TOOLKIT_META_ATTR = "_azure_functions_metadata"
+_TOOLKIT_META_ATTR = METADATA_ATTR
 
 
 class DbOut:
@@ -175,23 +182,20 @@ def _mark_decorator(fn: Callable[..., Any], name: str) -> None:
 def _merge_toolkit_metadata(
     fn: Callable[..., Any], namespace: str, payload: dict[str, Any],
 ) -> None:
-    """Merge toolkit metadata into the convention attribute, preserving other namespaces."""
-    existing: dict[str, Any] = getattr(fn, _TOOLKIT_META_ATTR, {})
+    """Merge toolkit metadata into the convention attribute, preserving other namespaces.
+
+    Backward-compatible shim delegating to the typed :func:`merge_db_metadata`
+    for the ``db`` namespace.
+    """
+    if namespace == NAMESPACE:
+        merge_db_metadata(fn, cast(DbMetadata, payload))
+        return
+
+    existing: dict[str, Any] = getattr(fn, METADATA_ATTR, {})
     if not isinstance(existing, dict):
         existing = {}
-
-    if namespace in existing and isinstance(existing[namespace], dict):
-        old = existing[namespace]
-        merged_payload = {**payload}
-        if "bindings" in old and "bindings" in payload:
-            merged_payload["bindings"] = old["bindings"] + payload["bindings"]
-        if "injections" in old and "injections" in payload:
-            merged_payload["injections"] = old["injections"] + payload["injections"]
-        existing = {**existing, namespace: merged_payload}
-    else:
-        existing = {**existing, namespace: payload}
-
-    setattr(fn, _TOOLKIT_META_ATTR, existing)
+    existing = {**existing, namespace: payload}
+    setattr(fn, METADATA_ATTR, existing)
 
 
 def _check_composition(fn: Callable[..., Any], name: str) -> None:
@@ -1270,9 +1274,5 @@ def get_db_metadata(func: Any) -> dict[str, Any] | None:
 
     Returns None if the function has no db metadata attached.
     """
-    toolkit_meta = getattr(func, _TOOLKIT_META_ATTR, None)
-    if isinstance(toolkit_meta, dict):
-        db_meta = toolkit_meta.get("db")
-        if isinstance(db_meta, dict):
-            return db_meta
-    return None
+    meta = read_db_metadata(func)
+    return dict(meta) if meta is not None else None

--- a/tests/test_metadata_contract.py
+++ b/tests/test_metadata_contract.py
@@ -1,0 +1,146 @@
+"""Tests for the typed ``db`` metadata contract (:mod:`azure_functions_db._metadata`)."""
+
+from __future__ import annotations
+
+from azure_functions_db import _metadata
+from azure_functions_db._metadata import (
+    DB_METADATA_VERSION,
+    METADATA_ATTR,
+    NAMESPACE,
+    merge_db_metadata,
+    read_db_metadata,
+)
+
+
+def _handler() -> object:
+    def fn() -> None: ...
+
+    return fn
+
+
+class TestContractConstants:
+    def test_attr_name(self) -> None:
+        assert METADATA_ATTR == "_azure_functions_metadata"
+
+    def test_namespace(self) -> None:
+        assert NAMESPACE == "db"
+
+    def test_version(self) -> None:
+        assert DB_METADATA_VERSION == 1
+
+
+class TestMergeDbMetadata:
+    def test_writes_payload(self) -> None:
+        fn = _handler()
+        payload = {
+            "version": 1,
+            "bindings": [{"kind": "trigger", "parameter": "events"}],
+            "injections": [],
+        }
+        merge_db_metadata(fn, payload)  # type: ignore[arg-type]
+
+        meta = getattr(fn, METADATA_ATTR)
+        assert meta == {NAMESPACE: payload}
+
+    def test_concatenates_bindings_and_injections(self) -> None:
+        fn = _handler()
+        merge_db_metadata(
+            fn,
+            {
+                "version": 1,
+                "bindings": [{"kind": "trigger", "parameter": "events"}],
+                "injections": [],
+            },
+        )
+        merge_db_metadata(
+            fn,
+            {
+                "version": 1,
+                "bindings": [{"kind": "output", "parameter": "out"}],
+                "injections": [{"kind": "reader", "parameter": "reader"}],
+            },
+        )
+
+        db_meta = getattr(fn, METADATA_ATTR)[NAMESPACE]
+        assert [b["parameter"] for b in db_meta["bindings"]] == ["events", "out"]
+        assert [i["parameter"] for i in db_meta["injections"]] == ["reader"]
+
+    def test_preserves_other_namespaces(self) -> None:
+        fn = _handler()
+        setattr(fn, METADATA_ATTR, {"logging": {"version": 1}})
+        merge_db_metadata(
+            fn,
+            {"version": 1, "bindings": [], "injections": []},
+        )
+
+        meta = getattr(fn, METADATA_ATTR)
+        assert meta["logging"] == {"version": 1}
+        assert meta[NAMESPACE] == {"version": 1, "bindings": [], "injections": []}
+
+    def test_ignores_non_dict_attr(self) -> None:
+        fn = _handler()
+        setattr(fn, METADATA_ATTR, "invalid")
+        merge_db_metadata(
+            fn,
+            {"version": 1, "bindings": [], "injections": []},
+        )
+
+        meta = getattr(fn, METADATA_ATTR)
+        assert meta == {NAMESPACE: {"version": 1, "bindings": [], "injections": []}}
+
+    def test_ignores_non_dict_namespace(self) -> None:
+        fn = _handler()
+        setattr(fn, METADATA_ATTR, {NAMESPACE: "bad"})
+        merge_db_metadata(
+            fn,
+            {"version": 1, "bindings": [], "injections": []},
+        )
+
+        db_meta = getattr(fn, METADATA_ATTR)[NAMESPACE]
+        assert db_meta == {"version": 1, "bindings": [], "injections": []}
+
+
+class TestReadDbMetadata:
+    def test_returns_payload_when_present(self) -> None:
+        fn = _handler()
+        payload = {"version": 1, "bindings": [], "injections": []}
+        setattr(fn, METADATA_ATTR, {NAMESPACE: payload})
+
+        assert read_db_metadata(fn) == payload
+
+    def test_returns_none_when_attr_missing(self) -> None:
+        assert read_db_metadata(_handler()) is None
+
+    def test_returns_none_when_attr_not_dict(self) -> None:
+        fn = _handler()
+        setattr(fn, METADATA_ATTR, "invalid")
+        assert read_db_metadata(fn) is None
+
+    def test_returns_none_when_namespace_missing(self) -> None:
+        fn = _handler()
+        setattr(fn, METADATA_ATTR, {"logging": {"version": 1}})
+        assert read_db_metadata(fn) is None
+
+    def test_returns_none_when_namespace_not_dict(self) -> None:
+        fn = _handler()
+        setattr(fn, METADATA_ATTR, {NAMESPACE: "bad"})
+        assert read_db_metadata(fn) is None
+
+
+class TestMergeShimGenericNamespace:
+    """The decorator shim also supports non-``db`` namespaces generically."""
+
+    def test_writes_foreign_namespace(self) -> None:
+        from azure_functions_db import decorator as decorator_mod
+
+        fn = _handler()
+        decorator_mod._merge_toolkit_metadata(fn, "other", {"version": 1})
+        assert getattr(fn, _metadata.METADATA_ATTR) == {"other": {"version": 1}}
+
+    def test_foreign_namespace_ignores_non_dict_attr(self) -> None:
+        from azure_functions_db import decorator as decorator_mod
+
+        fn = _handler()
+        setattr(fn, _metadata.METADATA_ATTR, "invalid")
+        decorator_mod._merge_toolkit_metadata(fn, "other", {"version": 1})
+        assert getattr(fn, _metadata.METADATA_ATTR) == {"other": {"version": 1}}

--- a/tests/test_metadata_contract.py
+++ b/tests/test_metadata_contract.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from azure_functions_db import _metadata
 from azure_functions_db._metadata import (
     DB_METADATA_VERSION,
@@ -12,7 +14,7 @@ from azure_functions_db._metadata import (
 )
 
 
-def _handler() -> object:
+def _handler() -> Any:
     def fn() -> None: ...
 
     return fn


### PR DESCRIPTION
## Summary
Introduces a typed `_azure_functions_metadata` contract for the `db` namespace, replacing the ad-hoc untyped dict merge.

- Add `src/azure_functions_db/_metadata.py` defining `DbMetadata` / `BindingEntry` / `InjectionEntry` TypedDicts, namespace/version constants, and typed `merge_db_metadata` / `read_db_metadata` helpers.
- Refactor `decorator.py`: `_merge_toolkit_metadata` is now a thin backward-compatible shim delegating to `merge_db_metadata` for the `db` namespace; `get_db_metadata` delegates to `read_db_metadata`.
- Add `tests/test_metadata_contract.py`.

Behavior-preserving: payload shape (`version`, `bindings`, `injections`) and the multi-decorator concatenation semantics are unchanged. TypedDict kept internal (not exported) to avoid public-API churn. Existing `test_toolkit_metadata.py` / `test_decorator.py` pass unchanged; coverage 95.43%.

Part of #196