### PR TITLE
refactor(binding): extract shared reflect_table helper

### DIFF
--- a/src/azure_functions_db/adapter/sqlalchemy.py
+++ b/src/azure_functions_db/adapter/sqlalchemy.py
@@ -15,7 +15,7 @@ from sqlalchemy.sql import and_, literal_column, or_, select, text
 from ..core.config import DbConfig, resolve_env_vars
 from ..core.engine import EngineProvider
 from ..core.errors import ConfigurationError
-from ..core.metadata import get_metadata_cache
+from ..core.metadata import reflect_table
 from ..core.types import CursorValue, RawRecord, SourceDescriptor
 from ..trigger.errors import FetchError, SourceConfigurationError
 
@@ -198,24 +198,15 @@ class SqlAlchemySource:
         assert self._engine is not None  # noqa: S101  # nosec B101
         assert self._table_name is not None  # noqa: S101  # nosec B101
 
-        cache = get_metadata_cache()
-        try:
-            table = cache.get_or_reflect(
-                engine=self._engine,
-                url=self._url,
-                schema=self._schema,
-                table_name=self._table_name,
-            )
-        except Exception as exc:
-            msg = f"Failed to reflect table '{self._table_name}'"
-            raise SourceConfigurationError(msg) from exc
+        self._table = reflect_table(
+            engine=self._engine,
+            url=self._url,
+            schema=self._schema,
+            table_name=self._table_name,
+            error_cls=SourceConfigurationError,
+        )
 
         key = f"{self._schema}.{self._table_name}" if self._schema else self._table_name
-        if table is None:
-            msg = f"Table '{key}' not found in database"
-            raise SourceConfigurationError(msg)
-
-        self._table = table
         assert self._table is not None  # noqa: S101  # nosec B101
 
         table_columns = {c.name for c in self._table.columns}

--- a/src/azure_functions_db/binding/reader.py
+++ b/src/azure_functions_db/binding/reader.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql import and_, select, text
 from ..core.config import DbConfig, resolve_env_vars
 from ..core.engine import EngineProvider
 from ..core.errors import ConfigurationError, DbConnectionError, QueryError
-from ..core.metadata import get_metadata_cache
+from ..core.metadata import reflect_table
 from ..core.validation import validate_pk_columns
 
 logger = logging.getLogger(__name__)
@@ -103,7 +103,7 @@ class DbReader:
         assert self._engine is not None  # noqa: S101  # nosec B101
         assert self._table is not None  # noqa: S101  # nosec B101
 
-        self._validate_pk_columns(pk)
+        validate_pk_columns(self._table, self._table_name, pk)
 
         try:
             conditions = [self._table.c[col] == val for col, val in pk.items()]
@@ -420,27 +420,10 @@ class DbReader:
         """Reflect table metadata and cache the Table object."""
         assert self._engine is not None  # noqa: S101  # nosec B101
         assert self._table_name is not None  # noqa: S101  # nosec B101
-
-        cache = get_metadata_cache()
-        try:
-            table = cache.get_or_reflect(
-                engine=self._engine,
-                url=self._url,
-                schema=self._schema,
-                table_name=self._table_name,
-            )
-        except Exception as exc:
-            msg = f"Failed to reflect table '{self._table_name}'"
-            raise ConfigurationError(msg) from exc
-
-        key = f"{self._schema}.{self._table_name}" if self._schema else self._table_name
-        if table is None:
-            msg = f"Table '{key}' not found in database"
-            raise ConfigurationError(msg)
-
-        self._table = table
-
-    def _validate_pk_columns(self, pk: dict[str, object]) -> None:
-        """Validate that *pk* keys exactly match the table's primary key columns."""
-        assert self._table is not None  # noqa: S101  # nosec B101
-        validate_pk_columns(self._table, self._table_name, pk)
+        self._table = reflect_table(
+            engine=self._engine,
+            url=self._url,
+            schema=self._schema,
+            table_name=self._table_name,
+            error_cls=ConfigurationError,
+        )

--- a/src/azure_functions_db/binding/writer.py
+++ b/src/azure_functions_db/binding/writer.py
@@ -14,7 +14,7 @@ from sqlalchemy.sql import and_, delete, update
 from ..core.config import DbConfig, resolve_env_vars
 from ..core.engine import EngineProvider
 from ..core.errors import ConfigurationError, DbConnectionError, WriteError
-from ..core.metadata import get_metadata_cache
+from ..core.metadata import reflect_table
 from ..core.validation import validate_pk_columns
 
 logger = logging.getLogger(__name__)
@@ -258,7 +258,7 @@ class DbWriter:
         assert self._table is not None  # noqa: S101  # nosec B101
 
         self._validate_data_columns(data)
-        self._validate_pk_columns(pk)
+        validate_pk_columns(self._table, self._table_name, pk)
 
         try:
             conditions = [self._table.c[col] == val for col, val in pk.items()]
@@ -280,7 +280,7 @@ class DbWriter:
         assert self._engine is not None  # noqa: S101  # nosec B101
         assert self._table is not None  # noqa: S101  # nosec B101
 
-        self._validate_pk_columns(pk)
+        validate_pk_columns(self._table, self._table_name, pk)
 
         try:
             conditions = [self._table.c[col] == val for col, val in pk.items()]
@@ -412,25 +412,13 @@ class DbWriter:
 
     def _reflect_table(self) -> None:
         assert self._engine is not None  # noqa: S101  # nosec B101
-
-        cache = get_metadata_cache()
-        try:
-            table = cache.get_or_reflect(
-                engine=self._engine,
-                url=self._url,
-                schema=self._schema,
-                table_name=self._table_name,
-            )
-        except Exception as exc:
-            msg = f"Failed to reflect table '{self._table_name}'"
-            raise ConfigurationError(msg) from exc
-
-        key = f"{self._schema}.{self._table_name}" if self._schema else self._table_name
-        if table is None:
-            msg = f"Table '{key}' not found in database"
-            raise ConfigurationError(msg)
-
-        self._table = table
+        self._table = reflect_table(
+            engine=self._engine,
+            url=self._url,
+            schema=self._schema,
+            table_name=self._table_name,
+            error_cls=ConfigurationError,
+        )
 
     def _validate_data_columns(self, data: dict[str, object]) -> None:
         assert self._table is not None  # noqa: S101  # nosec B101
@@ -444,11 +432,6 @@ class DbWriter:
         if unknown:
             msg = f"Unknown columns in data: {sorted(unknown)}"
             raise ConfigurationError(msg)
-
-    def _validate_pk_columns(self, pk: dict[str, object]) -> None:
-        """Validate that *pk* keys exactly match the table's primary key columns."""
-        assert self._table is not None  # noqa: S101  # nosec B101
-        validate_pk_columns(self._table, self._table_name, pk)
 
     def _validate_conflict_columns(self, conflict_columns: list[str]) -> None:
         assert self._table is not None  # noqa: S101  # nosec B101

--- a/src/azure_functions_db/core/metadata.py
+++ b/src/azure_functions_db/core/metadata.py
@@ -8,6 +8,39 @@ from sqlalchemy.schema import MetaData, Table
 from .config import resolve_env_vars
 
 
+def reflect_table(
+    *,
+    engine: Engine,
+    url: str,
+    schema: str | None,
+    table_name: str,
+    error_cls: type[Exception],
+) -> Table:
+    """Reflect *table_name* through the shared metadata cache and return it.
+
+    Shared by ``DbReader``, ``DbWriter``, and ``SqlAlchemySource``.  Raises an
+    instance of *error_cls* when reflection fails or the table is not found so
+    each caller keeps its domain-specific error type.
+    """
+    cache = get_metadata_cache()
+    try:
+        table = cache.get_or_reflect(
+            engine=engine,
+            url=url,
+            schema=schema,
+            table_name=table_name,
+        )
+    except Exception as exc:
+        msg = f"Failed to reflect table '{table_name}'"
+        raise error_cls(msg) from exc
+
+    key = f"{schema}.{table_name}" if schema else table_name
+    if table is None:
+        msg = f"Table '{key}' not found in database"
+        raise error_cls(msg)
+    return table
+
+
 class MetadataCache:
     def __init__(self) -> None:
         self._lock: threading.Lock = threading.Lock()


### PR DESCRIPTION
## Context

Part of #196 (item 3). Unifies the triplicated init/reflect/validate lifecycle shared by `DbReader`, `DbWriter`, and `SqlAlchemySource`, and removes the byte-identical `_validate_pk_columns` duplication.

## What changed

- Add `core.metadata.reflect_table(*, engine, url, schema, table_name, error_cls)` — the common cache lookup + None-check + message formatting that was copy-pasted across three `_reflect_table` methods. Parameterized by `error_cls` so each caller keeps its domain error type.
- `DbReader._reflect_table`, `DbWriter._reflect_table`, `SqlAlchemySource._reflect_table` now delegate to it. The adapter keeps its extra cursor/pk column + index validation on top.
- Remove the identical `_validate_pk_columns` wrapper methods from reader and writer; the three call sites now invoke the already-imported `validate_pk_columns` directly (the surrounding `_ensure_initialized()` already asserts `self._table is not None`).

Net: 60 insertions / 70 deletions.

## Behavior preservation

- Error **types** preserved: `ConfigurationError` (reader/writer) vs `SourceConfigurationError` (adapter).
- Error **messages** unchanged (`Failed to reflect table '...'`, `Table '...' not found in database`).
- Adapter's post-reflect required-column and cursor-index checks preserved verbatim.

## Verification

- `hatch run typecheck` (mypy) — clean, 69 files.
- `hatch run lint` (ruff) — clean.
- `hatch run bandit -r src` — 0 issues.
- `pytest` on reader/writer/adapter/metadata/decorator suites — 330 passed.

Part of #196