### PR TITLE
docs: require translation sync in the same PR as English changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,11 @@
 - Guarantee claims must be honest (pseudo trigger, at-least-once).
 - Pin every external GitHub Action `uses:` ref to a full commit SHA with a `# vX.Y.Z` comment. See [`CONTRIBUTING.md` § "GitHub Actions Pinning"](CONTRIBUTING.md#github-actions-pinning) for the policy and approved exceptions.
 
+### Documentation & Translations
+- When a change touches `README.md` or any English documentation, update the translated READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) **in the same PR** so translations never drift from the English source.
+- This applies to any code change that alters documented behavior, CLI output, or the ecosystem/package table — not just direct edits to prose.
+- If a full translation cannot land in the same PR, add a short "translation pending" note to the affected translated file and open a tracking issue before merging.
+
 ## Issue Conventions
 
 Follow these conventions when opening issues so the backlog stays consistent with sibling DX Toolkit repositories.


### PR DESCRIPTION
## Summary
Adds a **Documentation & Translations** rule to `AGENTS.md` under `## Working Rules`: whenever a change touches `README.md` or English docs (including code changes that alter documented behavior, CLI output, or the ecosystem table), the translated READMEs (`README.ko.md` / `README.ja.md` / `README.zh-CN.md`) must be updated **in the same PR**.

Codifies the practice applied when syncing the Ecosystem tables across the toolkit.

Closes #219