### PR TITLE
chore(deps): cap azure-functions below 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ classifiers = [
 ]
 
 dependencies = [
+    # Cap below 2.0.0: azure-functions v2 may change worker function-indexing
+    # behavior the toolkit relies on. See knowledge#46 / dx#8.
     "azure-functions>=1.22.0,<2.0.0",
     "sqlalchemy>=2.0",
     "azure-storage-blob>=12.21.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "azure-functions>=1.22.0",
+    "azure-functions>=1.22.0,<2.0.0",
     "sqlalchemy>=2.0",
     "azure-storage-blob>=12.21.0",
     "pydantic>=2.7",


### PR DESCRIPTION
## Context
Part of the DX Toolkit dependency-bound unification tracked in yeongseon/azure-functions-python-dx#8. `azure-functions` was pinned with a lower bound only (`>=1.22.0`), so a future `azure-functions` 2.x major could be installed and silently break v2 decorator behavior.

## Changes
- `pyproject.toml`: `azure-functions>=1.22.0` → `azure-functions>=1.22.0,<2.0.0`.

## Verification
- `make check-all` → EXIT=0 (all tests + lint + type check + security scan pass).

Refs yeongseon/azure-functions-python-dx#8