### PR TITLE
chore: drop stale noqa directives

### DIFF
--- a/src/azure_functions_db/adapter/sqlalchemy.py
+++ b/src/azure_functions_db/adapter/sqlalchemy.py
@@ -126,7 +126,7 @@ class SqlAlchemySource:
     def _compute_name(self) -> str:
         if self._table_name:
             return self._table_name
-        assert self._query is not None  # noqa: S101  # nosec B101
+        assert self._query is not None  # nosec B101
         query_hash = hashlib.sha256(self._query.encode()).hexdigest()[:12]
         return f"query_{query_hash}"
 
@@ -195,8 +195,8 @@ class SqlAlchemySource:
 
     def _reflect_table(self) -> None:
         """Reflect table metadata and validate that required columns exist."""
-        assert self._engine is not None  # noqa: S101  # nosec B101
-        assert self._table_name is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
+        assert self._table_name is not None  # nosec B101
 
         self._table = reflect_table(
             engine=self._engine,
@@ -207,7 +207,7 @@ class SqlAlchemySource:
         )
 
         key = f"{self._schema}.{self._table_name}" if self._schema else self._table_name
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._table is not None  # nosec B101
 
         table_columns = {c.name for c in self._table.columns}
         required = {self._cursor_column, *self._pk_columns}
@@ -244,7 +244,7 @@ class SqlAlchemySource:
         Returns an empty sequence when no new records are available.
         """
         self._ensure_initialized()
-        assert self._engine is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
 
         try:
             stmt = self._build_query(cursor, batch_size)
@@ -264,7 +264,7 @@ class SqlAlchemySource:
         return self._build_raw_query(cursor, batch_size)
 
     def _build_table_query(self, cursor: CursorValue | None, batch_size: int) -> Any:
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._table is not None  # nosec B101
 
         stmt = select(self._table)
 
@@ -287,7 +287,7 @@ class SqlAlchemySource:
         return stmt
 
     def _build_raw_query(self, cursor: CursorValue | None, batch_size: int) -> Any:
-        assert self._query is not None  # noqa: S101  # nosec B101
+        assert self._query is not None  # nosec B101
 
         subq = text(self._query).columns().subquery("source")
 
@@ -313,7 +313,7 @@ class SqlAlchemySource:
 
     def _build_cursor_filter_table(self, cursor: CursorValue) -> Any:
         """Build lexicographic cursor predicate for table mode."""
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._table is not None  # nosec B101
 
         cols_values = self._cursor_cols_values(cursor)
         col_exprs = [self._table.c[name] for name, _ in cols_values]

--- a/src/azure_functions_db/binding/reader.py
+++ b/src/azure_functions_db/binding/reader.py
@@ -100,8 +100,8 @@ class DbReader:
             raise ConfigurationError(msg)
 
         self._ensure_initialized()
-        assert self._engine is not None  # noqa: S101  # nosec B101
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
+        assert self._table is not None  # nosec B101
 
         validate_pk_columns(self._table, self._table_name, pk)
 
@@ -165,7 +165,7 @@ class DbReader:
                 stacklevel=2,
             )
         self._ensure_initialized()
-        assert self._engine is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
 
         try:
             stmt = text(sql)
@@ -222,7 +222,7 @@ class DbReader:
                 stacklevel=2,
             )
         self._ensure_initialized()
-        assert self._engine is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
 
         try:
             stmt = text(sql)
@@ -339,7 +339,7 @@ class DbReader:
     ) -> list[dict[str, object]]:
         """Execute *sql* and return up to two rows as dicts."""
         self._ensure_initialized()
-        assert self._engine is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
 
         try:
             stmt = text(sql)
@@ -418,8 +418,8 @@ class DbReader:
 
     def _reflect_table(self) -> None:
         """Reflect table metadata and cache the Table object."""
-        assert self._engine is not None  # noqa: S101  # nosec B101
-        assert self._table_name is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
+        assert self._table_name is not None  # nosec B101
         self._table = reflect_table(
             engine=self._engine,
             url=self._url,

--- a/src/azure_functions_db/binding/writer.py
+++ b/src/azure_functions_db/binding/writer.py
@@ -104,7 +104,7 @@ class DbWriter:
             raise WriteError(msg)
 
         self._ensure_initialized()
-        assert self._engine is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
 
         try:
             conn = self._engine.connect()
@@ -156,8 +156,8 @@ class DbWriter:
         database errors.
         """
         self._ensure_initialized()
-        assert self._engine is not None  # noqa: S101  # nosec B101
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
+        assert self._table is not None  # nosec B101
 
         self._validate_data_columns(data)
 
@@ -176,8 +176,8 @@ class DbWriter:
             return
 
         self._ensure_initialized()
-        assert self._engine is not None  # noqa: S101  # nosec B101
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
+        assert self._table is not None  # nosec B101
 
         for row in rows:
             self._validate_data_columns(row)
@@ -203,8 +203,8 @@ class DbWriter:
         raise :class:`ConfigurationError`.
         """
         self._ensure_initialized()
-        assert self._engine is not None  # noqa: S101  # nosec B101
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
+        assert self._table is not None  # nosec B101
 
         self._validate_data_columns(data)
         self._validate_conflict_columns(conflict_columns)
@@ -230,8 +230,8 @@ class DbWriter:
             return
 
         self._ensure_initialized()
-        assert self._engine is not None  # noqa: S101  # nosec B101
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
+        assert self._table is not None  # nosec B101
 
         for row in rows:
             self._validate_data_columns(row)
@@ -254,8 +254,8 @@ class DbWriter:
         This is a no-op if no row matches the given *pk* (idempotent).
         """
         self._ensure_initialized()
-        assert self._engine is not None  # noqa: S101  # nosec B101
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
+        assert self._table is not None  # nosec B101
 
         self._validate_data_columns(data)
         validate_pk_columns(self._table, self._table_name, pk)
@@ -277,8 +277,8 @@ class DbWriter:
         This is a no-op if no row matches the given *pk* (idempotent).
         """
         self._ensure_initialized()
-        assert self._engine is not None  # noqa: S101  # nosec B101
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
+        assert self._table is not None  # nosec B101
 
         validate_pk_columns(self._table, self._table_name, pk)
 
@@ -367,7 +367,7 @@ class DbWriter:
         Outside, each operation gets its own short-lived ``engine.begin()``
         transaction, preserving the previous behavior.
         """
-        assert self._engine is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
 
         if self._tx_conn is not None:
             yield self._tx_conn
@@ -411,7 +411,7 @@ class DbWriter:
         self._initialized = True
 
     def _reflect_table(self) -> None:
-        assert self._engine is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
         self._table = reflect_table(
             engine=self._engine,
             url=self._url,
@@ -421,7 +421,7 @@ class DbWriter:
         )
 
     def _validate_data_columns(self, data: dict[str, object]) -> None:
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._table is not None  # nosec B101
 
         if not data:
             msg = "data must not be empty"
@@ -434,7 +434,7 @@ class DbWriter:
             raise ConfigurationError(msg)
 
     def _validate_conflict_columns(self, conflict_columns: list[str]) -> None:
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._table is not None  # nosec B101
 
         if not conflict_columns:
             msg = "conflict_columns must not be empty"
@@ -451,8 +451,8 @@ class DbWriter:
         data: dict[str, object],
         conflict_columns: list[str],
     ) -> Any:
-        assert self._engine is not None  # noqa: S101  # nosec B101
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
+        assert self._table is not None  # nosec B101
 
         dialect = self._engine.dialect.name
         update_columns = {k: v for k, v in data.items() if k not in conflict_columns}
@@ -474,8 +474,8 @@ class DbWriter:
         conflict_columns: list[str],
         update_columns: dict[str, object],
     ) -> Any:
-        assert self._engine is not None  # noqa: S101  # nosec B101
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._engine is not None  # nosec B101
+        assert self._table is not None  # nosec B101
 
         dialect = self._engine.dialect.name
         if dialect == "postgresql":
@@ -488,7 +488,7 @@ class DbWriter:
         conflict_columns: list[str],
         update_columns: dict[str, object],
     ) -> Any:
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._table is not None  # nosec B101
 
         from sqlalchemy.dialects.postgresql import insert as pg_insert
 
@@ -508,7 +508,7 @@ class DbWriter:
         conflict_columns: list[str],
         update_columns: dict[str, object],
     ) -> Any:
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._table is not None  # nosec B101
 
         from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
@@ -527,7 +527,7 @@ class DbWriter:
         data: dict[str, object],
         update_columns: dict[str, object],
     ) -> Any:
-        assert self._table is not None  # noqa: S101  # nosec B101
+        assert self._table is not None  # nosec B101
 
         from sqlalchemy.dialects.mysql import insert as mysql_insert
 

--- a/src/azure_functions_db/state/blob.py
+++ b/src/azure_functions_db/state/blob.py
@@ -39,7 +39,7 @@ def _effective_grace(ttl_seconds: int) -> float:
 def _parse_lease_id(lease_id: str) -> tuple[str, int]:
     """Split ``owner_id:fencing_token`` into its parts."""
     parts = lease_id.rsplit(":", maxsplit=1)
-    if len(parts) != 2:  # noqa: PLR2004
+    if len(parts) != 2:
         msg = f"Invalid lease_id format: {lease_id!r}"
         raise ValueError(msg)
     owner_id, token_str = parts
@@ -301,7 +301,7 @@ class BlobCheckpointStore:
         try:
             self._write_state_conditional(poller_name, state, etag)
         except HttpResponseError as exc:
-            if exc.status_code == 412:  # noqa: PLR2004
+            if exc.status_code == 412:
                 raise LeaseConflictError(
                     f"CAS conflict acquiring lease for poller '{poller_name}'"
                 ) from exc
@@ -338,7 +338,7 @@ class BlobCheckpointStore:
         try:
             self._write_state_conditional(poller_name, state, etag)
         except HttpResponseError as exc:
-            if exc.status_code == 412:  # noqa: PLR2004
+            if exc.status_code == 412:
                 raise LostLeaseError(
                     f"CAS conflict renewing lease for poller '{poller_name}'"
                 ) from exc
@@ -369,7 +369,7 @@ class BlobCheckpointStore:
         try:
             self._write_state_conditional(poller_name, state, etag)
         except HttpResponseError as exc:
-            if exc.status_code == 412:  # noqa: PLR2004
+            if exc.status_code == 412:
                 raise LostLeaseError(
                     f"CAS conflict releasing lease for poller '{poller_name}'"
                 ) from exc
@@ -413,7 +413,7 @@ class BlobCheckpointStore:
         try:
             self._write_state_conditional(poller_name, state, etag)
         except HttpResponseError as exc:
-            if exc.status_code == 412:  # noqa: PLR2004
+            if exc.status_code == 412:
                 raise LostLeaseError(
                     f"CAS conflict committing checkpoint for poller '{poller_name}'"
                 ) from exc

--- a/src/azure_functions_db/trigger/runner.py
+++ b/src/azure_functions_db/trigger/runner.py
@@ -187,7 +187,7 @@ class PollRunner:
         max_attempts = 1 if policy is None else policy.max_retries + 1
         for attempt in range(max_attempts):
             try:
-                if self._handler_arity >= 2:  # noqa: PLR2004
+                if self._handler_arity >= 2:
                     self._handler(events, context)
                 else:
                     self._handler(events)


### PR DESCRIPTION
## Context
Part of the cross-repo legacy/dead-code cleanup (safe deletions only). These `# noqa` codes are no longer triggered under the repo's ruff configuration (`select = ["E", "F", "I"]`), so they suppress nothing and only add noise.

## Changes
Comment-only edits (45 insertions / 45 deletions), no logic changes. Removed **39× `S101`** and **6× `PLR2004`** across:
- `adapter/sqlalchemy.py`
- `binding/reader.py`
- `binding/writer.py`
- `state/blob.py`
- `trigger/runner.py`

**The `# nosec B101` bandit suppressions on assert lines are preserved** (only the stale ruff `# noqa: S101` portion is removed).

## Acceptance Checklist
- [x] `make check-all` passes locally (ruff, tests, bandit — security scan clean)
- [x] `ruff check src` → All checks passed
- [x] All 39 `# nosec B101` suppressions retained
- [x] No behavioral change (comment-only edits)

## Out of scope
- False-positive "dead code" (`__exit__` protocol params, tested public API) intentionally left untouched.