### PR TITLE
ci: add release-gate workflow drift lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,13 @@ check: ensure-hatch
 	@$(MAKE) typecheck
 	@echo "Lint and type check passed."
 
+.PHONY: lint-workflows
+lint-workflows: ensure-hatch
+	@$(HATCH) run python tools/lint_release_workflows.py
+
 .PHONY: check-all
 check-all: ensure-hatch
+	@$(MAKE) lint-workflows
 	@$(MAKE) check
 	@$(MAKE) test
 	@$(MAKE) security

--- a/tests/test_release_workflow_pins.py
+++ b/tests/test_release_workflow_pins.py
@@ -1,0 +1,89 @@
+"""Regression guard for the release-gate drift-lint.
+
+Exercises tools/lint_release_workflows.py against this repo (must be clean) and
+against synthetic drift (must be caught). Keeps the vendored lint honest.
+
+Family-agnostic: the runtime-tier assertions are derived from the lint's own
+``REQUIRED_RUNTIME_TIERS`` config, so this same test file is valid across the
+cookbook / runtime-gate / minimal repo families.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LINT_PATH = _REPO_ROOT / "tools" / "lint_release_workflows.py"
+
+_spec = importlib.util.spec_from_file_location("lint_release_workflows", _LINT_PATH)
+assert _spec and _spec.loader
+lint_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lint_mod)
+
+
+def _needs(*extra: str) -> str:
+    """Build a ``publish`` job stub with the universal needs plus ``extra``."""
+    items = list(lint_mod.UNIVERSAL_REQUIRED_NEEDS) + list(extra)
+    return f"  publish:\n    needs: [{', '.join(items)}]\n"
+
+
+def test_repo_release_workflows_are_clean() -> None:
+    """The committed gate workflows must satisfy the canonical pins + gate."""
+    assert lint_mod.lint() == []
+
+
+def test_detects_non_canonical_pin() -> None:
+    text = "      - uses: actions/checkout@" + "0" * 40 + " # v7.0.1\n"
+    errors = lint_mod.check_pins(text, "fake.yml")
+    assert errors and "expected canonical" in errors[0]
+
+
+def test_detects_annotation_drift() -> None:
+    sha, _ = lint_mod.CANONICAL_ACTIONS["actions/checkout"]
+    text = f"      - uses: actions/checkout@{sha} # v6\n"
+    errors = lint_mod.check_pins(text, "fake.yml")
+    assert errors and "annotation" in errors[0]
+
+
+def test_detects_unpinned_tag() -> None:
+    text = "      - uses: actions/checkout@v7.0.1\n"
+    errors = lint_mod.check_pins(text, "fake.yml")
+    assert errors and "not pinned to a 40-hex SHA" in errors[0]
+
+
+def test_detects_missing_verify_azure_certification() -> None:
+    # Drop verify-azure-certification while keeping build + lib-tests + tiers.
+    tiers = ", ".join(lint_mod.REQUIRED_RUNTIME_TIERS)
+    joined = "build, lib-tests" + (f", {tiers}" if tiers else "")
+    text = f"  publish:\n    needs: [{joined}]\n"
+    errors = lint_mod.check_publish_needs(text, "publish-pypi.yml")
+    assert any("verify-azure-certification" in e for e in errors)
+
+
+def test_detects_regressed_needs() -> None:
+    text = "  publish:\n    needs: [build, lib-tests]\n"
+    errors = lint_mod.check_publish_needs(text, "publish-pypi.yml")
+    assert any("regressed to build+lib-tests" in e for e in errors)
+
+
+@pytest.mark.skipif(
+    not lint_mod.REQUIRED_RUNTIME_TIERS,
+    reason="minimal family has no required runtime tier",
+)
+def test_detects_missing_runtime_tier() -> None:
+    # Universal needs present but the family-required runtime tier missing.
+    text = _needs()
+    errors = lint_mod.check_publish_needs(text, "publish-pypi.yml")
+    assert any("runtime tier" in e for e in errors)
+
+
+def test_parses_block_style_needs() -> None:
+    all_needs = list(lint_mod.UNIVERSAL_REQUIRED_NEEDS) + list(lint_mod.REQUIRED_RUNTIME_TIERS)
+    body = "  publish:\n    needs:\n"
+    for item in all_needs:
+        body += f"      - {item}\n"
+    body += "    runs-on: ubuntu-latest\n"
+    assert lint_mod.check_publish_needs(body, "publish-pypi.yml") == []

--- a/tools/lint_release_workflows.py
+++ b/tools/lint_release_workflows.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Drift-lint for the release-gate GitHub Actions workflows.
+
+Part of the DX Toolkit tiered pre-publish verification gate
+(umbrella: yeongseon/azure-functions-validation-python#306).
+
+This guards two invariants in ``publish-pypi.yml`` and ``e2e-azure.yml`` so the
+release gate cannot silently regress:
+
+1. **Pinned-action consistency.** Every shared action is pinned to the canonical
+   40-hex commit SHA *and* carries the canonical ``# vX`` annotation. The SHA is
+   the real security boundary; the annotation is human-readable evidence for
+   reviewers. Both are asserted.
+
+2. **Publish-gate wiring.** The ``publish`` job's ``needs`` must always include
+   ``build``, ``lib-tests`` and ``verify-azure-certification``, plus this repo's
+   required runtime tier(s). The gate must never regress to publishing on
+   ``build`` + ``lib-tests`` alone.
+
+The ``publish.needs`` list legitimately varies across three repo families
+(cookbook / runtime-gate / minimal); this repo's family is configured below, so
+the lint tolerates that variation while still enforcing the universal invariant.
+
+Vendored per-repo by design (there is no shared workflow repo). Keep the
+``CANONICAL_ACTIONS`` table and the ``REPO_FAMILY`` / ``REQUIRED_RUNTIME_TIERS``
+config in sync across the fleet when they change.
+
+Stdlib-only on purpose: the lint must not itself depend on a package that can
+drift. Exit code 0 = clean, 1 = drift detected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+# --- Fleet-wide canonical pins (action -> (sha, annotation)) ------------------
+CANONICAL_ACTIONS: dict[str, tuple[str, str]] = {
+    "actions/checkout": ("3d3c42e5aac5ba805825da76410c181273ba90b1", "v7.0.1"),
+    "actions/setup-python": ("5fda3b95a4ea91299a34e894583c3862153e4b97", "v7.0.0"),
+    "azure/login": ("f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca", "v3.0.1"),
+    "actions/upload-artifact": ("ea165f8d65b6e75b540449e92b4886f43607fa02", "v4"),
+    "actions/download-artifact": ("d3f86a106a0bac45b974a628896c90dbdf5c8093", "v4"),
+}
+
+# --- Per-repo configuration ---------------------------------------------------
+# Family is set explicitly (never inferred from the repo name): silent
+# misclassification would be worse than this one-line duplication.
+#   "cookbook"     -> requires cookbook-smoke + cookbook-host-smoke
+#   "runtime-gate" -> requires the package-specific <pkg>-runtime-gate job
+#   "minimal"      -> verify-azure-certification is itself the runtime proof
+REPO_FAMILY = "runtime-gate"
+REQUIRED_RUNTIME_TIERS: tuple[str, ...] = ("db-runtime-gate",)
+
+# Universal invariant across every repo, regardless of family.
+UNIVERSAL_REQUIRED_NEEDS = ("build", "lib-tests", "verify-azure-certification")
+
+GATE_WORKFLOWS = (
+    ".github/workflows/publish-pypi.yml",
+    ".github/workflows/e2e-azure.yml",
+)
+
+_USES_RE = re.compile(
+    r"""uses:\s*(?P<action>[\w.\-]+/[\w.\-]+)@(?P<ref>\S+?)      # owner/name@ref
+        (?:\s+\#\s*(?P<annotation>\S+))?\s*$                     # optional # annotation
+    """,
+    re.VERBOSE,
+)
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def check_pins(text: str, rel_path: str) -> list[str]:
+    """Assert every canonical action is pinned to its canonical SHA + annotation."""
+    errors: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        m = _USES_RE.search(line)
+        if not m:
+            continue
+        action = m.group("action")
+        if action not in CANONICAL_ACTIONS:
+            continue
+        ref = m.group("ref")
+        annotation = m.group("annotation")
+        want_sha, want_ann = CANONICAL_ACTIONS[action]
+        if not _SHA_RE.match(ref):
+            errors.append(
+                f"{rel_path}:{lineno}: {action} is not pinned to a 40-hex SHA "
+                f"(found '{ref}'); expected {want_sha} # {want_ann}"
+            )
+            continue
+        if ref != want_sha:
+            errors.append(
+                f"{rel_path}:{lineno}: {action} pinned to {ref} # {annotation}; "
+                f"expected canonical {want_sha} # {want_ann}"
+            )
+        elif annotation != want_ann:
+            errors.append(
+                f"{rel_path}:{lineno}: {action}@{ref} annotation is "
+                f"'# {annotation}'; expected '# {want_ann}'"
+            )
+    return errors
+
+
+def _extract_publish_needs(text: str) -> list[str] | None:
+    """Return the ``publish`` job's ``needs`` list, or None if not found.
+
+    Scans the block under the 2-space-indented ``publish:`` job header until the
+    next job header, then reads the ``needs:`` value. Handles both flow style
+    (``needs: [a, b]``) and block style (``needs:\\n    - a``).
+    """
+    lines = text.splitlines()
+    in_publish = False
+    for i, line in enumerate(lines):
+        if re.match(r"^  publish:\s*$", line):
+            in_publish = True
+            continue
+        if in_publish and re.match(r"^  \w[\w-]*:\s*$", line):
+            break  # next job header -> left the publish block
+        if not in_publish:
+            continue
+        flow = re.match(r"^\s+needs:\s*\[(?P<items>.*)\]\s*$", line)
+        if flow:
+            return [x.strip() for x in flow.group("items").split(",") if x.strip()]
+        block = re.match(r"^\s+needs:\s*$", line)
+        if block:
+            items: list[str] = []
+            for follow in lines[i + 1 :]:
+                item = re.match(r"^\s+-\s*(?P<name>\S+)\s*$", follow)
+                if not item:
+                    break
+                items.append(item.group("name"))
+            return items
+    return None
+
+
+def check_publish_needs(text: str, rel_path: str) -> list[str]:
+    """Assert the publish gate keeps the universal + family-required tiers."""
+    errors: list[str] = []
+    needs = _extract_publish_needs(text)
+    if needs is None:
+        return [f"{rel_path}: could not locate the 'publish' job's 'needs' list"]
+    needs_set = set(needs)
+
+    for required in UNIVERSAL_REQUIRED_NEEDS:
+        if required not in needs_set:
+            errors.append(
+                f"{rel_path}: publish.needs is missing required gate '{required}' "
+                f"(found {sorted(needs_set)})"
+            )
+    for tier in REQUIRED_RUNTIME_TIERS:
+        if tier not in needs_set:
+            errors.append(
+                f"{rel_path}: publish.needs is missing '{tier}' runtime tier "
+                f"required for the '{REPO_FAMILY}' family (found {sorted(needs_set)})"
+            )
+    if needs_set == {"build", "lib-tests"}:
+        errors.append(
+            f"{rel_path}: publish.needs regressed to build+lib-tests only; "
+            f"a runtime verification tier is mandatory"
+        )
+    return errors
+
+
+def lint(root: Path | None = None) -> list[str]:
+    """Run all checks; return a flat list of human-readable violations."""
+    root = root or _repo_root()
+    errors: list[str] = []
+    for rel in GATE_WORKFLOWS:
+        path = root / rel
+        if not path.exists():
+            errors.append(f"{rel}: expected release-gate workflow is missing")
+            continue
+        text = path.read_text(encoding="utf-8")
+        errors.extend(check_pins(text, rel))
+        if rel.endswith("publish-pypi.yml"):
+            errors.extend(check_publish_needs(text, rel))
+    return errors
+
+
+def main() -> int:
+    errors = lint()
+    if errors:
+        print("Release-workflow drift detected:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    print("Release-gate workflows: pins and publish gate are canonical.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Propagates the release-gate drift lint (runtime-gate family, `db-runtime-gate`) from azure-functions-validation (validation#306, tracker validation#318). Guards publish-pypi.yml / e2e-azure.yml against silent pin + publish-gate needs regression. `make check-all` green. Closes #243