### PR TITLE
ci: adopt Renovate for GitHub Actions bumps (renovate.json + drift-lint annotations)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["github-actions", "custom.regex"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Keep CANONICAL_ACTIONS pins in tools/lint_release_workflows.py in sync with the workflow uses: SHAs so bot-authored bumps pass the drift lint.",
+      "managerFilePatterns": ["^tools/lint_release_workflows\\.py$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\n\\s*\"[^\"]+\": \\(\"(?<currentDigest>[a-f0-9]{40})\", \"(?<currentValue>v[^\"]+)\"\\)"
+      ],
+      "autoReplaceStringTemplate": "# renovate: datasource={{{datasource}}} depName={{{depName}}} versioning={{{versioning}}}\n    \"{{{depName}}}\": (\"{{{newDigest}}}\", \"{{{newValue}}}\")"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Group the five release-gate action bumps so the workflow pin and the CANONICAL_ACTIONS constant land in one PR that keeps the drift lint green.",
+      "matchManagers": ["github-actions", "custom.regex"],
+      "matchPackageNames": [
+        "actions/checkout",
+        "actions/setup-python",
+        "azure/login",
+        "actions/upload-artifact",
+        "actions/download-artifact"
+      ],
+      "groupName": "release-gate GitHub Actions pins"
+    },
+    {
+      "description": "Group github/codeql-action steps (init/analyze) into one PR so they always move in lockstep; split bumps fail CodeQL Analyze with a version mismatch.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["github/codeql-action"],
+      "groupName": "codeql-action"
+    }
+  ]
+}

--- a/tools/lint_release_workflows.py
+++ b/tools/lint_release_workflows.py
@@ -37,10 +37,15 @@ import sys
 
 # --- Fleet-wide canonical pins (action -> (sha, annotation)) ------------------
 CANONICAL_ACTIONS: dict[str, tuple[str, str]] = {
+    # renovate: datasource=github-tags depName=actions/checkout versioning=github-tags
     "actions/checkout": ("3d3c42e5aac5ba805825da76410c181273ba90b1", "v7.0.1"),
+    # renovate: datasource=github-tags depName=actions/setup-python versioning=github-tags
     "actions/setup-python": ("5fda3b95a4ea91299a34e894583c3862153e4b97", "v7.0.0"),
+    # renovate: datasource=github-tags depName=azure/login versioning=github-tags
     "azure/login": ("f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca", "v3.0.1"),
+    # renovate: datasource=github-tags depName=actions/upload-artifact versioning=github-tags
     "actions/upload-artifact": ("ea165f8d65b6e75b540449e92b4886f43607fa02", "v4"),
+    # renovate: datasource=github-tags depName=actions/download-artifact versioning=github-tags
     "actions/download-artifact": ("d3f86a106a0bac45b974a628896c90dbdf5c8093", "v4"),
 }
 


### PR DESCRIPTION
## Summary
- Add `renovate.json` (`github-actions` + `custom.regex` managers) so a single Renovate PR updates both the workflow `uses:` SHA and the `CANONICAL_ACTIONS` pin in `tools/lint_release_workflows.py`, keeping the release-gate drift lint green.
- Add `# renovate:` annotations above each of the five `CANONICAL_ACTIONS` entries (required by the regex customManager).
- Group the five release-gate actions and the `github/codeql-action` init/analyze steps so grouped bumps never mismatch.

## Safety
- **Additive only.** Dependabot `github-actions` is intentionally left in place; removal is deferred until the Renovate GitHub App is confirmed active (separate admin-gated follow-up), to avoid a no-automation gap.
- Drift lint (`tools/lint_release_workflows.py`) and pin lint (`tools/lint_workflow_pins.py`) pass locally; `renovate.json` is valid JSON.

Closes #251