### PR TITLE
docs: consolidate official documentation URL onto yeongseon.dev

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -9,7 +9,7 @@
 [![Release](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-db-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-db-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-db-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/db/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Read this in: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
@@ -351,7 +351,7 @@ trigger = PollTrigger(
 
 ## Documentation
 
-- Full docs: [yeongseon.github.io/azure-functions-db-python](https://yeongseon.github.io/azure-functions-db-python/)
+- Full docs: [yeongseon.dev/azure-functions-python/db](https://yeongseon.dev/azure-functions-python/db/)
 - Examples: `examples/`
 - [Architecture](docs/02-architecture.md)
 - [Semantics](docs/03-semantics.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,7 +9,7 @@
 [![Release](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-db-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-db-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-db-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/db/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Read this in: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -351,7 +351,7 @@ trigger = PollTrigger(
 
 ## 문서
 
-- 전체 문서: [yeongseon.github.io/azure-functions-db-python](https://yeongseon.github.io/azure-functions-db-python/)
+- 전체 문서: [yeongseon.dev/azure-functions-python/db](https://yeongseon.dev/azure-functions-python/db/)
 - 예제: `examples/`
 - [Architecture](docs/02-architecture.md)
 - [Semantics](docs/03-semantics.md)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-db-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-db-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-db-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/db/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Read this in: [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -589,7 +589,7 @@ See [Semantics — Duplicate Windows](docs/03-semantics.md#13-duplicate-and-repr
 
 ## Documentation
 
-- Full docs: [yeongseon.github.io/azure-functions-db-python](https://yeongseon.github.io/azure-functions-db-python/)
+- Full docs: [yeongseon.dev/azure-functions-python/db](https://yeongseon.dev/azure-functions-python/db/)
 - Examples: `examples/`
 - [Architecture](docs/02-architecture.md)
 - [Semantics](docs/03-semantics.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 [![Release](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-db-python/actions/workflows/publish-pypi.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-db-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-db-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-db-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/db/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Read this in: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
@@ -351,7 +351,7 @@ trigger = PollTrigger(
 
 ## Documentation
 
-- Full docs: [yeongseon.github.io/azure-functions-db-python](https://yeongseon.github.io/azure-functions-db-python/)
+- Full docs: [yeongseon.dev/azure-functions-python/db](https://yeongseon.dev/azure-functions-python/db/)
 - Examples: `examples/`
 - [Architecture](docs/02-architecture.md)
 - [Semantics](docs/03-semantics.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,23 +5,23 @@
 Part of the **Azure Functions Python DX Toolkit**. SQLAlchemy-backed database bindings and a pseudo-trigger for Azure Functions Python v2 — read, write, and react to database changes with a decorator-based API. Install from PyPI with `pip install azure-functions-db`.
 
 ## Getting Started
-- [Installation](https://yeongseon.github.io/azure-functions-db-python/installation/): Install the package.
-- [Quickstart](https://yeongseon.github.io/azure-functions-db-python/getting-started/): Minimal end-to-end example.
+- [Installation](https://yeongseon.dev/azure-functions-python/db/installation/): Install the package.
+- [Quickstart](https://yeongseon.dev/azure-functions-python/db/getting-started/): Minimal end-to-end example.
 
 ## User Guide
-- [Architecture](https://yeongseon.github.io/azure-functions-db-python/02-architecture/): How the bindings and runtime fit together.
-- [Binding Semantics](https://yeongseon.github.io/azure-functions-db-python/22-binding-semantics/): Input/output binding behavior.
-- [Polling Runtime & Failure Scenarios](https://yeongseon.github.io/azure-functions-db-python/24-polling-runtime-semantics/): Trigger runtime semantics.
-- [EngineProvider & Pooling](https://yeongseon.github.io/azure-functions-db-python/25-engine-provider-pooling/): Connection pooling.
-- [Python API Spec](https://yeongseon.github.io/azure-functions-db-python/04-python-api-spec/): Public API.
+- [Architecture](https://yeongseon.dev/azure-functions-python/db/02-architecture/): How the bindings and runtime fit together.
+- [Binding Semantics](https://yeongseon.dev/azure-functions-python/db/22-binding-semantics/): Input/output binding behavior.
+- [Polling Runtime & Failure Scenarios](https://yeongseon.dev/azure-functions-python/db/24-polling-runtime-semantics/): Trigger runtime semantics.
+- [EngineProvider & Pooling](https://yeongseon.dev/azure-functions-python/db/25-engine-provider-pooling/): Connection pooling.
+- [Python API Spec](https://yeongseon.dev/azure-functions-python/db/04-python-api-spec/): Public API.
 
 ## Examples
-- [Input Binding](https://yeongseon.github.io/azure-functions-db-python/examples/input_binding/): Read rows.
-- [Output Binding](https://yeongseon.github.io/azure-functions-db-python/examples/output_binding/): Write rows.
-- [Trigger](https://yeongseon.github.io/azure-functions-db-python/examples/trigger/): React to changes.
-- [Client Injection](https://yeongseon.github.io/azure-functions-db-python/examples/client_injection/): Imperative access.
+- [Input Binding](https://yeongseon.dev/azure-functions-python/db/examples/input_binding/): Read rows.
+- [Output Binding](https://yeongseon.dev/azure-functions-python/db/examples/output_binding/): Write rows.
+- [Trigger](https://yeongseon.dev/azure-functions-python/db/examples/trigger/): React to changes.
+- [Client Injection](https://yeongseon.dev/azure-functions-python/db/examples/client_injection/): Imperative access.
 
 ## Reference
-- [API Reference](https://yeongseon.github.io/azure-functions-db-python/api/): Public API surface.
-- [FAQ](https://yeongseon.github.io/azure-functions-db-python/faq/): Frequently asked questions.
-- [Troubleshooting](https://yeongseon.github.io/azure-functions-db-python/troubleshooting/): Common issues and fixes.
+- [API Reference](https://yeongseon.dev/azure-functions-python/db/api/): Public API surface.
+- [FAQ](https://yeongseon.dev/azure-functions-python/db/faq/): Frequently asked questions.
+- [Troubleshooting](https://yeongseon.dev/azure-functions-python/db/troubleshooting/): Common issues and fixes.

--- a/drafts/blog-beyond-azure-sql-bindings.md
+++ b/drafts/blog-beyond-azure-sql-bindings.md
@@ -39,7 +39,7 @@ trigger that works with **any database that ships a SQLAlchemy dialect**.
 > For the full axis-by-axis breakdown (databases, trigger mechanism, scaling,
 > delivery guarantee, checkpoint storage, local testing, SQLAlchemy/BYOD,
 > production readiness), see the
-> [comparison page](https://yeongseon.github.io/azure-functions-db-python/) _(verify link)_
+> [comparison page](https://yeongseon.dev/azure-functions-python/db/) _(verify link)_
 > and [ADR-006 — Python Wrapper over Native Extension](https://github.com/yeongseon/azure-functions-db/blob/main/docs/27-ADR-006-no-native-extension.md).
 
 ## Not a native binding — and that's a deliberate choice
@@ -177,7 +177,7 @@ pip install azure-functions-db[postgres]
 ```
 
 - Package: <https://pypi.org/project/azure-functions-db/>
-- Docs: <https://yeongseon.github.io/azure-functions-db-python/>
+- Docs: <https://yeongseon.dev/azure-functions-python/db/>
 - Source & examples: <https://github.com/yeongseon/azure-functions-db>
 
 *This is an independent community project and is not affiliated with, endorsed

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,7 +8,7 @@
 - Version: 0.1.0
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-db-python/
+- Docs: https://yeongseon.dev/azure-functions-python/db/
 - Repository: https://github.com/yeongseon/azure-functions-db-python
 - Azure Functions programming model: v2
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@
 - Version: 0.1.0
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-db-python/
+- Docs: https://yeongseon.dev/azure-functions-python/db/
 - Repository: https://github.com/yeongseon/azure-functions-db-python
 
 ## What It Does
@@ -66,9 +66,9 @@ pip install azure-functions-db-python[all]        # All drivers
 
 ## Documentation
 
-- [Architecture](https://yeongseon.github.io/azure-functions-db-python/02-architecture/)
-- [Semantics](https://yeongseon.github.io/azure-functions-db-python/03-semantics/)
-- [Python API Spec](https://yeongseon.github.io/azure-functions-db-python/04-python-api-spec/)
+- [Architecture](https://yeongseon.dev/azure-functions-python/db/02-architecture/)
+- [Semantics](https://yeongseon.dev/azure-functions-python/db/03-semantics/)
+- [Python API Spec](https://yeongseon.dev/azure-functions-python/db/04-python-api-spec/)
 
 ## Ecosystem
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Azure Functions DB
 site_description: Unified DB integration (trigger + input/output binding) for Azure Functions Python v2
 site_author: Yeongseon Choe
+site_url: https://yeongseon.dev/azure-functions-python/db/
 repo_url: https://github.com/yeongseon/azure-functions-db-python
 edit_uri: edit/main/docs/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://yeongseon.github.io/azure-functions-db-python/"
-Documentation = "https://yeongseon.github.io/azure-functions-db-python/"
+Homepage = "https://yeongseon.dev/azure-functions-python/db/"
+Documentation = "https://yeongseon.dev/azure-functions-python/db/"
 Repository = "https://github.com/yeongseon/azure-functions-db-python"
 Issues = "https://github.com/yeongseon/azure-functions-db-python/issues"
 


### PR DESCRIPTION
## Summary
Consolidates the DB package's official documentation URL onto the canonical domain `https://yeongseon.dev/azure-functions-python/db/`, replacing the old GitHub Pages host (`yeongseon.github.io/azure-functions-db-python`).

Changed surfaces:
- `pyproject.toml` — `Homepage` / `Documentation` (Repository/Issues stay on GitHub)
- `mkdocs.yml` — **set `site_url`** to the new canonical URL (was missing). `repo_url` / `edit_uri` stay on GitHub.
- README badge (`docs-gh--pages` → `docs-yeongseon.dev`) + doc links across all locales (en/ja/ko/zh-CN), including markdown link-text occurrences.

35 URL occurrences swapped + 1 new `site_url` line; subpaths/anchors preserved.

## Verification
- `mkdocs build --strict` passes (INFO-only).
- Root, sitemap, and all 15 distinct doc subpaths (architecture, semantics, api-spec, examples, runtime-semantics, etc.) return **200**; root serves real MkDocs Material 9.7.7 with self-referential canonical.
- 0 remaining github.io refs, 0 remaining docs-gh--pages badges.

## Notes
- The `.github/ISSUE_TEMPLATE/config.yml` link is a GitHub **security-advisory** URL (not a docs link) and is intentionally left unchanged.
- Repository/Issues and mkdocs `repo_url`/`edit_uri` intentionally remain on GitHub.
- No recipe.yaml/recipes.json metadata files exist in this repo.

Closes #253